### PR TITLE
feat/price

### DIFF
--- a/TonPrediction.Api/Program.cs
+++ b/TonPrediction.Api/Program.cs
@@ -4,6 +4,8 @@ using TonPrediction.Application.Database.Config;
 using TonPrediction.Infrastructure.Database;
 using TonPrediction.Infrastructure.Database.Migrations;
 using TonPrediction.Api.Services;
+using TonPrediction.Application.Services;
+using TonPrediction.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,6 +15,7 @@ builder.Services.AddControllers();
 builder.Services.AddSignalR();
 builder.Services.AddHttpClient();
 builder.Services.AddMultipleService("^TonPrediction");
+builder.Services.AddSingleton<IPriceService, BinancePriceService>();
 builder.Services.AddSingleton<ApplicationDbContext>();
 builder.Services.Configure<DatabaseConfig>(builder.Configuration.GetSection("ConnectionStrings:Default"));
 builder.Services.AddHostedService<TonPrediction.Api.Services.RoundScheduler>();

--- a/TonPrediction.Api/Services/PriceMonitor.cs
+++ b/TonPrediction.Api/Services/PriceMonitor.cs
@@ -39,7 +39,8 @@ namespace TonPrediction.Api.Services
 
         private async Task RecordPriceAsync(CancellationToken token)
         {
-            var price = await _priceService.GetCurrentPriceAsync(token);
+            var priceResult = await _priceService.GetAsync("ton", "usd", token);
+            var price = priceResult.Price;
             using var scope = _scopeFactory.CreateScope();
             var repo = scope.ServiceProvider.GetRequiredService<IPriceSnapshotRepository>();
             await repo.InsertAsync(new PriceSnapshotEntity

--- a/TonPrediction.Api/Services/RoundScheduler.cs
+++ b/TonPrediction.Api/Services/RoundScheduler.cs
@@ -47,7 +47,7 @@ namespace TonPrediction.Api.Services
             var priceRepo = scope.ServiceProvider.GetRequiredService<IPriceSnapshotRepository>();
             var priceService = scope.ServiceProvider.GetRequiredService<IPriceService>();
 
-            var startPrice = await priceService.GetCurrentPriceAsync(token);
+            var startPrice = (await priceService.GetAsync("ton", "usd", token)).Price;
             var now = DateTime.UtcNow;
             var round = new RoundEntity
             {
@@ -63,7 +63,7 @@ namespace TonPrediction.Api.Services
 
             await Task.Delay(_interval, token);
 
-            var closePrice = await priceService.GetCurrentPriceAsync(token);
+            var closePrice = (await priceService.GetAsync("ton", "usd", token)).Price;
             var closeTime = DateTime.UtcNow;
             round.CloseTime = closeTime;
             round.ClosePrice = closePrice;

--- a/TonPrediction.Application/Services/IPriceService.cs
+++ b/TonPrediction.Application/Services/IPriceService.cs
@@ -8,10 +8,15 @@ namespace TonPrediction.Application.Services
     public interface IPriceService : ITransientDependency
     {
         /// <summary>
-        /// 获取当前价格。
+        /// 获取某币种在指定法币中的最新价格。
         /// </summary>
-        /// <param name="token">取消任务标记。</param>
-        /// <returns>当前价格。</returns>
-        Task<decimal> GetCurrentPriceAsync(CancellationToken token);
+        /// <param name="symbol">币种符号，小写，如 "ton" 或 "btc"。</param>
+        /// <param name="vsCurrency">法币符号，默认为 usd。</param>
+        /// <param name="ct">取消任务标记。</param>
+        /// <returns>价格结果。</returns>
+        Task<PriceResult> GetAsync(
+            string symbol,
+            string vsCurrency = "usd",
+            CancellationToken ct = default);
     }
 }

--- a/TonPrediction.Application/Services/PriceResult.cs
+++ b/TonPrediction.Application/Services/PriceResult.cs
@@ -1,0 +1,15 @@
+namespace TonPrediction.Application.Services
+{
+    /// <summary>
+    /// 表示价格查询结果。
+    /// </summary>
+    /// <param name="Symbol">查询的币种符号。</param>
+    /// <param name="VsCurrency">法币符号。</param>
+    /// <param name="Price">对应价格。</param>
+    /// <param name="Timestamp">查询时间。</param>
+    public record PriceResult(
+        string Symbol,
+        string VsCurrency,
+        decimal Price,
+        DateTimeOffset Timestamp);
+}

--- a/TonPrediction.Infrastructure/Services/BinancePriceService.cs
+++ b/TonPrediction.Infrastructure/Services/BinancePriceService.cs
@@ -1,0 +1,134 @@
+using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using TonPrediction.Application.Services;
+
+namespace TonPrediction.Infrastructure.Services
+{
+    /// <summary>
+    /// 使用 Binance WebSocket 与 REST 获取价格。
+    /// </summary>
+    public class BinancePriceService(
+        IHttpClientFactory httpClientFactory,
+        ILogger<BinancePriceService> logger) : IPriceService, IDisposable
+    {
+        private readonly HttpClient _httpClient = httpClientFactory.CreateClient();
+        private readonly ILogger<BinancePriceService> _logger = logger;
+        private readonly ConcurrentDictionary<string, decimal> _prices = new();
+        private readonly ConcurrentDictionary<string, ClientWebSocket> _sockets = new();
+        private readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web);
+
+        /// <inheritdoc />
+        public async Task<PriceResult> GetAsync(
+            string symbol,
+            string vsCurrency = "usd",
+            CancellationToken ct = default)
+        {
+            var pair = (symbol + vsCurrency).ToUpperInvariant();
+            if (!_prices.TryGetValue(pair, out var price))
+            {
+                price = await FetchRestAsync(pair, ct);
+                _prices[pair] = price;
+                _ = EnsureWebSocketAsync(pair, ct);
+            }
+
+            return new PriceResult(symbol, vsCurrency, price, DateTimeOffset.UtcNow);
+        }
+
+        private async Task<decimal> FetchRestAsync(string pair, CancellationToken ct)
+        {
+            var url = $"https://api.binance.com/api/v3/ticker/price?symbol={pair}";
+            try
+            {
+                var resp = await _httpClient.GetFromJsonAsync<RestResponse>(url, ct);
+                return resp?.Price ?? 0m;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to fetch price from Binance REST");
+                return 0m;
+            }
+        }
+
+        private async Task EnsureWebSocketAsync(string pair, CancellationToken ct)
+        {
+            if (_sockets.ContainsKey(pair))
+                return;
+
+            try
+            {
+                var socket = new ClientWebSocket();
+                await socket.ConnectAsync(new Uri($"wss://stream.binance.com/ws/{pair.ToLower()}@trade"), ct);
+                if (_sockets.TryAdd(pair, socket))
+                {
+                    _ = Task.Run(() => ReceiveLoopAsync(pair, socket, ct));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to connect Binance WebSocket");
+            }
+        }
+
+        private async Task ReceiveLoopAsync(string pair, ClientWebSocket socket, CancellationToken ct)
+        {
+            var buffer = new byte[1024];
+            while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
+            {
+                try
+                {
+                    var result = await socket.ReceiveAsync(buffer, ct);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, ct);
+                        break;
+                    }
+
+                    var json = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                    var data = JsonSerializer.Deserialize<WsResponse>(json, _options);
+                    if (data != null)
+                    {
+                        _prices[pair] = data.Price;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Binance WebSocket receive error");
+                    break;
+                }
+            }
+        }
+
+        private sealed class RestResponse
+        {
+            [JsonPropertyName("price")]
+            public decimal Price { get; set; }
+        }
+
+        private sealed class WsResponse
+        {
+            [JsonPropertyName("p")]
+            public decimal Price { get; set; }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            foreach (var socket in _sockets.Values)
+            {
+                try
+                {
+                    socket.Abort();
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `IPriceService` with symbol/currency parameters
- introduce `PriceResult` record
- add Binance-based price service using WebSocket/REST
- update CoinGecko service and background jobs
- register `BinancePriceService` in API

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6867337760208323abf2be48b0521fb3