### PR TITLE
feat/api: add bet record endpoints

### DIFF
--- a/TonPrediction.Api/Controllers/PredictionsController.cs
+++ b/TonPrediction.Api/Controllers/PredictionsController.cs
@@ -1,0 +1,106 @@
+using Microsoft.AspNetCore.Mvc;
+using QYQ.Base.Common.ApiResult;
+using SqlSugar;
+using TonPrediction.Application.Database.Entities;
+using TonPrediction.Application.Database.Repository;
+using TonPrediction.Application.Enums;
+using TonPrediction.Application.Output;
+
+namespace TonPrediction.Api.Controllers;
+
+/// <summary>
+/// 下注记录与盈亏接口。
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public class PredictionsController(IBetRepository betRepo, IRoundRepository roundRepo) : ControllerBase
+{
+    private readonly IBetRepository _betRepo = betRepo;
+    private readonly IRoundRepository _roundRepo = roundRepo;
+
+    /// <summary>
+    /// 分页获取下注记录。
+    /// </summary>
+    [HttpGet("round")]
+    public async Task<ApiResult<List<BetRecordOutput>>> GetRoundAsync(
+        [FromQuery] string address,
+        [FromQuery] string status = "all",
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
+    {
+        page = page <= 0 ? 1 : page;
+        pageSize = pageSize is <= 0 or > 100 ? 10 : pageSize;
+        dynamic betDyn = _betRepo;
+        ISqlSugarClient db = betDyn.Db;
+        dynamic betQuery = db.Queryable<BetEntity>()
+            .Where("user_address = @address", new { address });
+        betQuery = status switch
+        {
+            "claimed" => betQuery.Where("claimed = true"),
+            "unclaimed" => betQuery.Where("claimed = false"),
+            _ => betQuery
+        };
+        var bets = (List<BetEntity>)await betQuery
+            .OrderBy("id", OrderByType.Desc)
+            .ToPageListAsync(page, pageSize);
+        var ids = bets.Select(b => b.Epoch).ToArray();
+        var rounds = (List<RoundEntity>)await db.Queryable<RoundEntity>()
+            .In(ids)
+            .ToListAsync();
+        var map = rounds.ToDictionary(r => r.Id);
+        var list = new List<BetRecordOutput>();
+        foreach (var bet in bets)
+        {
+            if (!map.TryGetValue(bet.Epoch, out var round))
+                continue;
+            var result = BetResult.Draw;
+            if (round.ClosePrice > round.LockPrice)
+                result = bet.Position == Position.Bull ? BetResult.Win : BetResult.Lose;
+            else if (round.ClosePrice < round.LockPrice)
+                result = bet.Position == Position.Bear ? BetResult.Win : BetResult.Lose;
+            var output = new BetRecordOutput
+            {
+                RoundId = bet.Epoch,
+                Position = bet.Position,
+                Amount = bet.Amount.ToString("F8"),
+                LockPrice = round.LockPrice.ToString("F8"),
+                ClosePrice = round.ClosePrice.ToString("F8"),
+                Reward = bet.Reward.ToString("F8"),
+                Claimed = bet.Claimed,
+                Result = result
+            };
+            list.Add(output);
+        }
+        var api = new ApiResult<List<BetRecordOutput>>();
+        api.SetRsult(ApiResultCode.Success, list);
+        return api;
+    }
+
+    /// <summary>
+    /// 获取盈亏汇总。
+    /// </summary>
+    [HttpGet("pnl")]
+    public async Task<ApiResult<PnlOutput>> GetPnlAsync([FromQuery] string address)
+    {
+        dynamic betDyn = _betRepo;
+        ISqlSugarClient db = betDyn.Db;
+        var bets = (List<BetEntity>)await db.Queryable<BetEntity>()
+            .Where("user_address = @address", new { address })
+            .ToListAsync();
+        var totalBet = bets.Sum(b => b.Amount);
+        var totalReward = bets.Sum(b => b.Reward);
+        var rounds = bets.Count;
+        var winRounds = bets.Count(b => b.Reward > 0m);
+        var output = new PnlOutput
+        {
+            TotalBet = totalBet.ToString("F8"),
+            TotalReward = totalReward.ToString("F8"),
+            NetProfit = (totalReward - totalBet).ToString("F8"),
+            Rounds = rounds,
+            WinRounds = winRounds
+        };
+        var api = new ApiResult<PnlOutput>();
+        api.SetRsult(ApiResultCode.Success, output);
+        return api;
+    }
+}

--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -102,12 +102,16 @@ namespace TonPrediction.Api.Services
                         new
                         {
                             roundId = round.Id,
-                            totalAmount = round.TotalAmount,
-                            upAmount = round.BullAmount,
-                            downAmount = round.BearAmount,
-                            rewardPool = round.RewardAmount,
-                            oddsUp = oddsBull,
-                            oddsDown = oddsBear
+                            lockPrice = round.LockPrice.ToString("F8"),
+                            currentPrice = round.ClosePrice > 0m ? round.ClosePrice.ToString("F8") : round.LockPrice.ToString("F8"),
+                            totalAmount = round.TotalAmount.ToString("F8"),
+                            upAmount = round.BullAmount.ToString("F8"),
+                            downAmount = round.BearAmount.ToString("F8"),
+                            rewardPool = round.RewardAmount.ToString("F8"),
+                            endTime = new DateTimeOffset(round.CloseTime).ToUnixTimeSeconds(),
+                            oddsUp = oddsBull.ToString("F8"),
+                            oddsDown = oddsBear.ToString("F8"),
+                            status = round.Status
                         },
                         stoppingToken);
                 }

--- a/TonPrediction.Application/Enums/BetResult.cs
+++ b/TonPrediction.Application/Enums/BetResult.cs
@@ -1,0 +1,22 @@
+namespace TonPrediction.Application.Enums;
+
+/// <summary>
+/// 下注结果。
+/// </summary>
+public enum BetResult
+{
+    /// <summary>
+    /// 平局。
+    /// </summary>
+    Draw = 0,
+
+    /// <summary>
+    /// 获胜。
+    /// </summary>
+    Win = 1,
+
+    /// <summary>
+    /// 失败。
+    /// </summary>
+    Lose = 2
+}

--- a/TonPrediction.Application/Output/BetRecordOutput.cs
+++ b/TonPrediction.Application/Output/BetRecordOutput.cs
@@ -1,0 +1,49 @@
+using TonPrediction.Application.Enums;
+
+namespace TonPrediction.Application.Output;
+
+/// <summary>
+/// 单个下注记录信息。
+/// </summary>
+public class BetRecordOutput
+{
+    /// <summary>
+    /// 回合编号。
+    /// </summary>
+    public long RoundId { get; set; }
+
+    /// <summary>
+    /// 下注方向。
+    /// </summary>
+    public Position Position { get; set; }
+
+    /// <summary>
+    /// 下注金额。
+    /// </summary>
+    public string Amount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 锁定价格。
+    /// </summary>
+    public string LockPrice { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 收盘价格。
+    /// </summary>
+    public string ClosePrice { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 奖励金额。
+    /// </summary>
+    public string Reward { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 是否已领取。
+    /// </summary>
+    public bool Claimed { get; set; }
+
+    /// <summary>
+    /// 结果。
+    /// </summary>
+    public BetResult Result { get; set; }
+}

--- a/TonPrediction.Application/Output/PnlOutput.cs
+++ b/TonPrediction.Application/Output/PnlOutput.cs
@@ -1,0 +1,32 @@
+namespace TonPrediction.Application.Output;
+
+/// <summary>
+/// 盈亏汇总信息。
+/// </summary>
+public class PnlOutput
+{
+    /// <summary>
+    /// 总下注金额。
+    /// </summary>
+    public string TotalBet { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 总奖励金额。
+    /// </summary>
+    public string TotalReward { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 净收益 = 总奖励 - 总下注。
+    /// </summary>
+    public string NetProfit { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 参与回合数。
+    /// </summary>
+    public int Rounds { get; set; }
+
+    /// <summary>
+    /// 获胜回合数。
+    /// </summary>
+    public int WinRounds { get; set; }
+}


### PR DESCRIPTION
## Summary
- add enum `BetResult`
- add output DTOs for bet records and PnL
- implement `PredictionsController` for `/api/predictions/round` and `/api/predictions/pnl`
- broadcast full `currentRound` info on price updates and new bets

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6867411a2e6c832388889f7718b68247