### PR TITLE
feat: move logic from controllers to services

### DIFF
--- a/TonPrediction.Api/Controllers/PredictionsController.cs
+++ b/TonPrediction.Api/Controllers/PredictionsController.cs
@@ -1,9 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using QYQ.Base.Common.ApiResult;
-using SqlSugar;
-using TonPrediction.Application.Database.Entities;
-using TonPrediction.Application.Database.Repository;
-using TonPrediction.Application.Enums;
+using TonPrediction.Application.Services;
 using TonPrediction.Application.Output;
 
 namespace TonPrediction.Api.Controllers;
@@ -13,10 +10,9 @@ namespace TonPrediction.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-public class PredictionsController(IBetRepository betRepo, IRoundRepository roundRepo) : ControllerBase
+public class PredictionsController(IPredictionService predictionService) : ControllerBase
 {
-    private readonly IBetRepository _betRepo = betRepo;
-    private readonly IRoundRepository _roundRepo = roundRepo;
+    private readonly IPredictionService _predictionService = predictionService;
 
     /// <summary>
     /// 分页获取下注记录。
@@ -28,49 +24,7 @@ public class PredictionsController(IBetRepository betRepo, IRoundRepository roun
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10)
     {
-        page = page <= 0 ? 1 : page;
-        pageSize = pageSize is <= 0 or > 100 ? 10 : pageSize;
-        dynamic betDyn = _betRepo;
-        ISqlSugarClient db = betDyn.Db;
-        dynamic betQuery = db.Queryable<BetEntity>()
-            .Where("user_address = @address", new { address });
-        betQuery = status switch
-        {
-            "claimed" => betQuery.Where("claimed = true"),
-            "unclaimed" => betQuery.Where("claimed = false"),
-            _ => betQuery
-        };
-        var bets = (List<BetEntity>)await betQuery
-            .OrderBy("id", OrderByType.Desc)
-            .ToPageListAsync(page, pageSize);
-        var ids = bets.Select(b => b.Epoch).ToArray();
-        var rounds = (List<RoundEntity>)await db.Queryable<RoundEntity>()
-            .In(ids)
-            .ToListAsync();
-        var map = rounds.ToDictionary(r => r.Id);
-        var list = new List<BetRecordOutput>();
-        foreach (var bet in bets)
-        {
-            if (!map.TryGetValue(bet.Epoch, out var round))
-                continue;
-            var result = BetResult.Draw;
-            if (round.ClosePrice > round.LockPrice)
-                result = bet.Position == Position.Bull ? BetResult.Win : BetResult.Lose;
-            else if (round.ClosePrice < round.LockPrice)
-                result = bet.Position == Position.Bear ? BetResult.Win : BetResult.Lose;
-            var output = new BetRecordOutput
-            {
-                RoundId = bet.Epoch,
-                Position = bet.Position,
-                Amount = bet.Amount.ToString("F8"),
-                LockPrice = round.LockPrice.ToString("F8"),
-                ClosePrice = round.ClosePrice.ToString("F8"),
-                Reward = bet.Reward.ToString("F8"),
-                Claimed = bet.Claimed,
-                Result = result
-            };
-            list.Add(output);
-        }
+        var list = await _predictionService.GetRecordsAsync(address, status, page, pageSize);
         var api = new ApiResult<List<BetRecordOutput>>();
         api.SetRsult(ApiResultCode.Success, list);
         return api;
@@ -82,23 +36,7 @@ public class PredictionsController(IBetRepository betRepo, IRoundRepository roun
     [HttpGet("pnl")]
     public async Task<ApiResult<PnlOutput>> GetPnlAsync([FromQuery] string address)
     {
-        dynamic betDyn = _betRepo;
-        ISqlSugarClient db = betDyn.Db;
-        var bets = (List<BetEntity>)await db.Queryable<BetEntity>()
-            .Where("user_address = @address", new { address })
-            .ToListAsync();
-        var totalBet = bets.Sum(b => b.Amount);
-        var totalReward = bets.Sum(b => b.Reward);
-        var rounds = bets.Count;
-        var winRounds = bets.Count(b => b.Reward > 0m);
-        var output = new PnlOutput
-        {
-            TotalBet = totalBet.ToString("F8"),
-            TotalReward = totalReward.ToString("F8"),
-            NetProfit = (totalReward - totalBet).ToString("F8"),
-            Rounds = rounds,
-            WinRounds = winRounds
-        };
+        var output = await _predictionService.GetPnlAsync(address);
         var api = new ApiResult<PnlOutput>();
         api.SetRsult(ApiResultCode.Success, output);
         return api;

--- a/TonPrediction.Api/Controllers/RoundController.cs
+++ b/TonPrediction.Api/Controllers/RoundController.cs
@@ -1,9 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using QYQ.Base.Common.ApiResult;
-using SqlSugar;
-using TonPrediction.Application.Database.Entities;
-using TonPrediction.Application.Database.Repository;
-using TonPrediction.Application.Enums;
+using TonPrediction.Application.Services;
 using TonPrediction.Application.Output;
 
 namespace TonPrediction.Api.Controllers;
@@ -13,10 +10,9 @@ namespace TonPrediction.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-public class RoundController(IRoundRepository roundRepo, IConfiguration configuration) : ControllerBase
+public class RoundController(IRoundService roundService) : ControllerBase
 {
-    private readonly IRoundRepository _roundRepo = roundRepo;
-    private readonly IConfiguration _configuration = configuration;
+    private readonly IRoundService _roundService = roundService;
 
     /// <summary>
     /// 获取历史回合列表。
@@ -24,28 +20,7 @@ public class RoundController(IRoundRepository roundRepo, IConfiguration configur
     [HttpGet("history")]
     public async Task<ApiResult<List<RoundHistoryOutput>>> GetHistoryAsync([FromQuery] int limit = 3)
     {
-        limit = limit is <= 0 or > 100 ? 3 : limit;
-        dynamic repoDyn = _roundRepo;
-        ISqlSugarClient db = repoDyn.Db;
-        dynamic query = db.Queryable<RoundEntity>();
-        var list = (List<RoundEntity>)await query
-            .Where("status = @status", new { status = (int)RoundStatus.Ended })
-            .OrderBy("id", OrderByType.Desc)
-            .Take(limit)
-            .ToListAsync();
-        var result = list.Select(r => new RoundHistoryOutput
-        {
-            RoundId = r.Id,
-            LockPrice = r.LockPrice.ToString("F8"),
-            ClosePrice = r.ClosePrice.ToString("F8"),
-            TotalAmount = r.TotalAmount.ToString("F8"),
-            UpAmount = r.BullAmount.ToString("F8"),
-            DownAmount = r.BearAmount.ToString("F8"),
-            RewardPool = r.RewardAmount.ToString("F8"),
-            EndTime = new DateTimeOffset(r.CloseTime).ToUnixTimeSeconds(),
-            OddsUp = r.BullAmount > 0m ? (r.TotalAmount / r.BullAmount).ToString("F8") : "0",
-            OddsDown = r.BearAmount > 0m ? (r.TotalAmount / r.BearAmount).ToString("F8") : "0"
-        }).ToList();
+        var result = await _roundService.GetHistoryAsync(limit);
         var api = new ApiResult<List<RoundHistoryOutput>>();
         api.SetRsult(ApiResultCode.Success, result);
         return api;
@@ -57,25 +32,7 @@ public class RoundController(IRoundRepository roundRepo, IConfiguration configur
     [HttpGet("upcoming")]
     public async Task<ApiResult<List<UpcomingRoundOutput>>> GetUpcomingAsync()
     {
-        dynamic repoDyn = _roundRepo;
-        ISqlSugarClient db = repoDyn.Db;
-        dynamic query = db.Queryable<RoundEntity>();
-        var latest = (RoundEntity?)await query
-            .OrderBy("id", OrderByType.Desc)
-            .FirstAsync();
-        var intervalSec = _configuration.GetValue<int>("ENV_ROUND_INTERVAL_SEC", 300);
-        var startTime = latest?.CloseTime ?? DateTime.UtcNow;
-        var list = new List<UpcomingRoundOutput>();
-        for (var i = 0; i < 2; i++)
-        {
-            var s = startTime.AddSeconds(intervalSec * i);
-            list.Add(new UpcomingRoundOutput
-            {
-                RoundId = new DateTimeOffset(s).ToUnixTimeSeconds(),
-                StartTime = new DateTimeOffset(s).ToUnixTimeSeconds(),
-                EndTime = new DateTimeOffset(s.AddSeconds(intervalSec)).ToUnixTimeSeconds()
-            });
-        }
+        var list = await _roundService.GetUpcomingAsync();
         var api = new ApiResult<List<UpcomingRoundOutput>>();
         api.SetRsult(ApiResultCode.Success, list);
         return api;

--- a/TonPrediction.Application/Services/IPredictionService.cs
+++ b/TonPrediction.Application/Services/IPredictionService.cs
@@ -1,0 +1,34 @@
+using QYQ.Base.Common.IOCExtensions;
+using TonPrediction.Application.Output;
+
+namespace TonPrediction.Application.Services;
+
+/// <summary>
+/// 预测记录查询业务接口。
+/// </summary>
+public interface IPredictionService : ITransientDependency
+{
+    /// <summary>
+    /// 分页获取指定地址的下注记录。
+    /// </summary>
+    /// <param name="address">用户地址。</param>
+    /// <param name="status">记录状态：all/claimed/unclaimed。</param>
+    /// <param name="page">页码。</param>
+    /// <param name="pageSize">每页条数。</param>
+    /// <param name="ct">取消任务标记。</param>
+    /// <returns>下注记录列表。</returns>
+    Task<List<BetRecordOutput>> GetRecordsAsync(
+        string address,
+        string status = "all",
+        int page = 1,
+        int pageSize = 10,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// 获取指定地址的盈亏汇总。
+    /// </summary>
+    /// <param name="address">用户地址。</param>
+    /// <param name="ct">取消任务标记。</param>
+    /// <returns>盈亏信息。</returns>
+    Task<PnlOutput> GetPnlAsync(string address, CancellationToken ct = default);
+}

--- a/TonPrediction.Application/Services/IRoundService.cs
+++ b/TonPrediction.Application/Services/IRoundService.cs
@@ -1,0 +1,27 @@
+using QYQ.Base.Common.IOCExtensions;
+using TonPrediction.Application.Output;
+
+namespace TonPrediction.Application.Services;
+
+/// <summary>
+/// 回合信息查询业务接口。
+/// </summary>
+public interface IRoundService : ITransientDependency
+{
+    /// <summary>
+    /// 获取历史回合列表。
+    /// </summary>
+    /// <param name="limit">最大返回数量。</param>
+    /// <param name="ct">取消任务标记。</param>
+    /// <returns>历史回合集合。</returns>
+    Task<List<RoundHistoryOutput>> GetHistoryAsync(
+        int limit = 3,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// 获取即将开始的回合时间。
+    /// </summary>
+    /// <param name="ct">取消任务标记。</param>
+    /// <returns>回合时间集合。</returns>
+    Task<List<UpcomingRoundOutput>> GetUpcomingAsync(CancellationToken ct = default);
+}

--- a/TonPrediction.Application/Services/PredictionService.cs
+++ b/TonPrediction.Application/Services/PredictionService.cs
@@ -1,0 +1,94 @@
+using SqlSugar;
+using TonPrediction.Application.Database.Entities;
+using TonPrediction.Application.Database.Repository;
+using TonPrediction.Application.Enums;
+using TonPrediction.Application.Output;
+
+namespace TonPrediction.Application.Services;
+
+/// <summary>
+/// 预测记录查询业务实现。
+/// </summary>
+public class PredictionService(
+    IBetRepository betRepo,
+    IRoundRepository roundRepo) : IPredictionService
+{
+    private readonly IBetRepository _betRepo = betRepo;
+    private readonly IRoundRepository _roundRepo = roundRepo;
+
+    /// <inheritdoc />
+    public async Task<List<BetRecordOutput>> GetRecordsAsync(
+        string address,
+        string status = "all",
+        int page = 1,
+        int pageSize = 10,
+        CancellationToken ct = default)
+    {
+        page = page <= 0 ? 1 : page;
+        pageSize = pageSize is <= 0 or > 100 ? 10 : pageSize;
+        dynamic betDyn = _betRepo;
+        ISqlSugarClient db = betDyn.Db;
+        dynamic betQuery = db.Queryable<BetEntity>()
+            .Where("user_address = @address", new { address });
+        betQuery = status switch
+        {
+            "claimed" => betQuery.Where("claimed = true"),
+            "unclaimed" => betQuery.Where("claimed = false"),
+            _ => betQuery
+        };
+        var bets = (List<BetEntity>)await betQuery
+            .OrderBy("id", OrderByType.Desc)
+            .ToPageListAsync(page, pageSize);
+        var ids = bets.Select(b => b.Epoch).ToArray();
+        var rounds = (List<RoundEntity>)await db.Queryable<RoundEntity>()
+            .In(ids)
+            .ToListAsync();
+        var map = rounds.ToDictionary(r => r.Id);
+        var list = new List<BetRecordOutput>();
+        foreach (var bet in bets)
+        {
+            if (!map.TryGetValue(bet.Epoch, out var round))
+                continue;
+            var result = BetResult.Draw;
+            if (round.ClosePrice > round.LockPrice)
+                result = bet.Position == Position.Bull ? BetResult.Win : BetResult.Lose;
+            else if (round.ClosePrice < round.LockPrice)
+                result = bet.Position == Position.Bear ? BetResult.Win : BetResult.Lose;
+            var output = new BetRecordOutput
+            {
+                RoundId = bet.Epoch,
+                Position = bet.Position,
+                Amount = bet.Amount.ToString("F8"),
+                LockPrice = round.LockPrice.ToString("F8"),
+                ClosePrice = round.ClosePrice.ToString("F8"),
+                Reward = bet.Reward.ToString("F8"),
+                Claimed = bet.Claimed,
+                Result = result
+            };
+            list.Add(output);
+        }
+        return list;
+    }
+
+    /// <inheritdoc />
+    public async Task<PnlOutput> GetPnlAsync(string address, CancellationToken ct = default)
+    {
+        dynamic betDyn = _betRepo;
+        ISqlSugarClient db = betDyn.Db;
+        var bets = (List<BetEntity>)await db.Queryable<BetEntity>()
+            .Where("user_address = @address", new { address })
+            .ToListAsync();
+        var totalBet = bets.Sum(b => b.Amount);
+        var totalReward = bets.Sum(b => b.Reward);
+        var rounds = bets.Count;
+        var winRounds = bets.Count(b => b.Reward > 0m);
+        return new PnlOutput
+        {
+            TotalBet = totalBet.ToString("F8"),
+            TotalReward = totalReward.ToString("F8"),
+            NetProfit = (totalReward - totalBet).ToString("F8"),
+            Rounds = rounds,
+            WinRounds = winRounds
+        };
+    }
+}

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Configuration;
+using SqlSugar;
+using TonPrediction.Application.Database.Entities;
+using TonPrediction.Application.Database.Repository;
+using TonPrediction.Application.Enums;
+using TonPrediction.Application.Output;
+
+namespace TonPrediction.Application.Services;
+
+/// <summary>
+/// 回合信息查询业务实现。
+/// </summary>
+public class RoundService(
+    IRoundRepository roundRepo,
+    IConfiguration configuration) : IRoundService
+{
+    private readonly IRoundRepository _roundRepo = roundRepo;
+    private readonly IConfiguration _configuration = configuration;
+
+    /// <inheritdoc />
+    public async Task<List<RoundHistoryOutput>> GetHistoryAsync(
+        int limit = 3,
+        CancellationToken ct = default)
+    {
+        limit = limit is <= 0 or > 100 ? 3 : limit;
+        dynamic repoDyn = _roundRepo;
+        ISqlSugarClient db = repoDyn.Db;
+        dynamic query = db.Queryable<RoundEntity>();
+        var list = (List<RoundEntity>)await query
+            .Where("status = @status", new { status = (int)RoundStatus.Ended })
+            .OrderBy("id", OrderByType.Desc)
+            .Take(limit)
+            .ToListAsync();
+        return list.Select(r => new RoundHistoryOutput
+        {
+            RoundId = r.Id,
+            LockPrice = r.LockPrice.ToString("F8"),
+            ClosePrice = r.ClosePrice.ToString("F8"),
+            TotalAmount = r.TotalAmount.ToString("F8"),
+            UpAmount = r.BullAmount.ToString("F8"),
+            DownAmount = r.BearAmount.ToString("F8"),
+            RewardPool = r.RewardAmount.ToString("F8"),
+            EndTime = new DateTimeOffset(r.CloseTime).ToUnixTimeSeconds(),
+            OddsUp = r.BullAmount > 0m ? (r.TotalAmount / r.BullAmount).ToString("F8") : "0",
+            OddsDown = r.BearAmount > 0m ? (r.TotalAmount / r.BearAmount).ToString("F8") : "0"
+        }).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<List<UpcomingRoundOutput>> GetUpcomingAsync(
+        CancellationToken ct = default)
+    {
+        dynamic repoDyn = _roundRepo;
+        ISqlSugarClient db = repoDyn.Db;
+        dynamic query = db.Queryable<RoundEntity>();
+        var latest = (RoundEntity?)await query
+            .OrderBy("id", OrderByType.Desc)
+            .FirstAsync();
+        var intervalSec = _configuration.GetValue<int>("ENV_ROUND_INTERVAL_SEC", 300);
+        var startTime = latest?.CloseTime ?? DateTime.UtcNow;
+        var list = new List<UpcomingRoundOutput>();
+        for (var i = 0; i < 2; i++)
+        {
+            var s = startTime.AddSeconds(intervalSec * i);
+            list.Add(new UpcomingRoundOutput
+            {
+                RoundId = new DateTimeOffset(s).ToUnixTimeSeconds(),
+                StartTime = new DateTimeOffset(s).ToUnixTimeSeconds(),
+                EndTime = new DateTimeOffset(s.AddSeconds(intervalSec)).ToUnixTimeSeconds()
+            });
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
## Summary
- extract business logic from `PredictionsController` and `RoundController`
- add new service interfaces and implementations in Application layer

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686744761be08323982846beb2c37f5b