### PR TITLE
refactor: move db logic to repositories

### DIFF
--- a/TonPrediction.Api/Services/RoundScheduler.cs
+++ b/TonPrediction.Api/Services/RoundScheduler.cs
@@ -52,11 +52,7 @@ namespace TonPrediction.Api.Services
             var priceService = scope.ServiceProvider.GetRequiredService<IPriceService>();
 
             var now = DateTime.UtcNow;
-            dynamic repoDyn = roundRepo;
-            var db = repoDyn.Db;
-            var current = await db.Queryable<RoundEntity>()
-                .OrderBy("id", SqlSugar.OrderByType.Desc)
-                .FirstAsync();
+            var current = await roundRepo.GetLatestAsync(token);
 
             if (current == null || current.Status == RoundStatus.Ended)
             {

--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -66,12 +66,7 @@ namespace TonPrediction.Api.Services
                     var betRepo = scope.ServiceProvider.GetRequiredService<IBetRepository>();
                     var roundRepo = scope.ServiceProvider.GetRequiredService<IRoundRepository>();
 
-                    dynamic repoDyn = roundRepo;
-                    var db = repoDyn.Db;
-                    var round = await db.Queryable<RoundEntity>()
-                        .Where("status = @status", new { status = (int)RoundStatus.Live })
-                        .OrderBy("id", SqlSugar.OrderByType.Desc)
-                        .FirstAsync();
+                    var round = await roundRepo.GetCurrentLiveAsync(stoppingToken);
                     if (round == null)
                         continue;
 

--- a/TonPrediction.Application/Database/Repository/IBetRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IBetRepository.cs
@@ -14,6 +14,28 @@ namespace TonPrediction.Application.Database.Repository
     /// </summary>
     public interface IBetRepository : IBaseRepository<BetEntity>, ITransientDependency
     {
+        /// <summary>
+        /// 获取指定地址的分页下注记录。
+        /// </summary>
+        /// <param name="address">用户地址。</param>
+        /// <param name="status">记录状态过滤。</param>
+        /// <param name="page">页码。</param>
+        /// <param name="pageSize">每页数量。</param>
+        /// <param name="ct">取消令牌。</param>
+        Task<List<BetEntity>> GetPagedByAddressAsync(
+            string address,
+            string status,
+            int page,
+            int pageSize,
+            CancellationToken ct = default);
 
+        /// <summary>
+        /// 获取指定地址的全部下注记录。
+        /// </summary>
+        /// <param name="address">用户地址。</param>
+        /// <param name="ct">取消令牌。</param>
+        Task<List<BetEntity>> GetByAddressAsync(
+            string address,
+            CancellationToken ct = default);
     }
 }

--- a/TonPrediction.Application/Database/Repository/IPriceSnapshotRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IPriceSnapshotRepository.cs
@@ -9,5 +9,13 @@ namespace TonPrediction.Application.Database.Repository
     /// </summary>
     public interface IPriceSnapshotRepository : IBaseRepository<PriceSnapshotEntity>, ITransientDependency
     {
+        /// <summary>
+        /// 获取指定时间之后的价格快照。
+        /// </summary>
+        /// <param name="since">起始时间。</param>
+        /// <param name="ct">取消令牌。</param>
+        Task<List<PriceSnapshotEntity>> GetSinceAsync(
+            DateTime since,
+            CancellationToken ct = default);
     }
 }

--- a/TonPrediction.Application/Database/Repository/IRoundRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IRoundRepository.cs
@@ -14,6 +14,30 @@ namespace TonPrediction.Application.Database.Repository
     /// </summary>
     public interface IRoundRepository : IBaseRepository<RoundEntity>, ITransientDependency
     {
+        /// <summary>
+        /// 获取最新一轮记录。
+        /// </summary>
+        /// <param name="ct">取消令牌。</param>
+        Task<RoundEntity?> GetLatestAsync(CancellationToken ct = default);
 
+        /// <summary>
+        /// 获取当前进行中的回合。
+        /// </summary>
+        /// <param name="ct">取消令牌。</param>
+        Task<RoundEntity?> GetCurrentLiveAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// 获取最近结束的若干回合。
+        /// </summary>
+        /// <param name="limit">限制数量。</param>
+        /// <param name="ct">取消令牌。</param>
+        Task<List<RoundEntity>> GetEndedAsync(int limit, CancellationToken ct = default);
+
+        /// <summary>
+        /// 根据编号批量查询回合。
+        /// </summary>
+        /// <param name="ids">回合编号集合。</param>
+        /// <param name="ct">取消令牌。</param>
+        Task<List<RoundEntity>> GetByIdsAsync(long[] ids, CancellationToken ct = default);
     }
 }

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -24,14 +24,7 @@ public class RoundService(
         CancellationToken ct = default)
     {
         limit = limit is <= 0 or > 100 ? 3 : limit;
-        dynamic repoDyn = _roundRepo;
-        ISqlSugarClient db = repoDyn.Db;
-        dynamic query = db.Queryable<RoundEntity>();
-        var list = (List<RoundEntity>)await query
-            .Where("status = @status", new { status = (int)RoundStatus.Ended })
-            .OrderBy("id", OrderByType.Desc)
-            .Take(limit)
-            .ToListAsync();
+        var list = await _roundRepo.GetEndedAsync(limit, ct);
         return list.Select(r => new RoundHistoryOutput
         {
             RoundId = r.Id,
@@ -51,12 +44,7 @@ public class RoundService(
     public async Task<List<UpcomingRoundOutput>> GetUpcomingAsync(
         CancellationToken ct = default)
     {
-        dynamic repoDyn = _roundRepo;
-        ISqlSugarClient db = repoDyn.Db;
-        dynamic query = db.Queryable<RoundEntity>();
-        var latest = (RoundEntity?)await query
-            .OrderBy("id", OrderByType.Desc)
-            .FirstAsync();
+        var latest = await _roundRepo.GetLatestAsync(ct);
         var intervalSec = _configuration.GetValue<int>("ENV_ROUND_INTERVAL_SEC", 300);
         var startTime = latest?.CloseTime ?? DateTime.UtcNow;
         var list = new List<UpcomingRoundOutput>();

--- a/TonPrediction.Infrastructure/Database/Repository/PriceSnapshotRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/PriceSnapshotRepository.cs
@@ -21,5 +21,15 @@ namespace TonPrediction.Infrastructure.Database.Repository
         : BaseRepository<PriceSnapshotEntity>(logger, options.CurrentValue.Default, dbType),
             IPriceSnapshotRepository
     {
+        /// <inheritdoc />
+        public async Task<List<PriceSnapshotEntity>> GetSinceAsync(
+            DateTime since,
+            CancellationToken ct = default)
+        {
+            return await Db.Queryable<PriceSnapshotEntity>()
+                .Where(p => p.Timestamp >= since)
+                .OrderBy(p => p.Timestamp, OrderByType.Asc)
+                .ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- move SqlSugar queries from services to repository layer
- expose repository methods for bet, round and price snapshot
- update API services to use repository methods

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68674c0982488323a9b7a10a38b2415d