### PR TITLE
feat(listener): improve TonEventListener

### DIFF
--- a/TonPrediction.Api/Program.cs
+++ b/TonPrediction.Api/Program.cs
@@ -7,6 +7,7 @@ using TonPrediction.Api.Services;
 using TonPrediction.Infrastructure.Services;
 using TonPrediction.Application.Services.Interface;
 using TonPrediction.Infrastructure;
+using System;
 using QYQ.Base.Swagger.Extension;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -16,6 +17,10 @@ builder.AddQYQSerilog();
 builder.Services.AddControllers();
 builder.Services.AddSignalR();
 builder.Services.AddHttpClient();
+builder.Services.AddHttpClient("TonApi", c =>
+{
+    c.BaseAddress = new Uri("https://tonapi.io");
+});
 builder.Services.AddMultipleService("^TonPrediction");
 builder.Services.AddSingleton<ApplicationDbContext>();
 builder.Services.AddSingleton<IPriceService, BinancePriceService>();

--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -67,7 +67,7 @@ public class TonEventListener(IServiceScopeFactory scopeFactory, IConfiguration 
                                 $"/v2/blockchain/transactions/{head.Tx_Hash}",
                                 stoppingToken);
 
-                        ProcessTransaction(detail!, stoppingToken);
+                        await ProcessTransactionAsync(detail!, stoppingToken);
                     }
                 }
             }
@@ -84,7 +84,12 @@ public class TonEventListener(IServiceScopeFactory scopeFactory, IConfiguration 
         }
     }
 
-    private async void ProcessTransaction(TonTxDetail tx, CancellationToken ct)
+    /// <summary>
+    /// 处理一笔入账交易。
+    /// </summary>
+    /// <param name="tx">交易详情。</param>
+    /// <param name="ct">取消令牌。</param>
+    internal virtual async Task ProcessTransactionAsync(TonTxDetail tx, CancellationToken ct)
     {
         var comment = tx.In_Message.Comment?.Trim().ToLowerInvariant();
         if (string.IsNullOrEmpty(comment)) return;
@@ -163,7 +168,7 @@ public record SseTxHead(string Account_Id, ulong Lt, string Tx_Hash);
 /// <param name="Amount">交易金额（nanoTON 已转普通 TON）</param>
 /// <param name="In_Message"></param>
 public record TonTxDetail(
-    decimal Amount,       
+    decimal Amount,
     InMsg In_Message);
 
 /// <summary>

--- a/TonPrediction.Api/TonPrediction.Api.csproj
+++ b/TonPrediction.Api/TonPrediction.Api.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="TonPrediction.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TonPrediction.Application\TonPrediction.Application.csproj" />
     <ProjectReference Include="..\TonPrediction.Infrastructure\TonPrediction.Infrastructure.csproj" />
   </ItemGroup>

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using PancakeSwap.Api.Hubs;
+using TonPrediction.Api.Services;
+using TonPrediction.Application.Database.Entities;
+using TonPrediction.Application.Database.Repository;
+using TonPrediction.Application.Enums;
+using Xunit;
+
+namespace TonPrediction.Test;
+
+/// <summary>
+/// TonEventListener 单元测试。
+/// </summary>
+public class TonEventListenerTests
+{
+    [Fact]
+    public async Task ProcessTransactionAsync_InsertsBetAndUpdatesRound()
+    {
+        var round = new RoundEntity
+        {
+            Symbol = "ton",
+            Id = 1,
+            CloseTime = DateTime.UtcNow.AddMinutes(5),
+            LockPrice = 1m,
+            Status = RoundStatus.Live
+        };
+
+        var betRepo = new Mock<IBetRepository>();
+        betRepo.Setup(b => b.InsertAsync(It.IsAny<BetEntity>()))
+            .ReturnsAsync(new BetEntity())
+            .Verifiable();
+
+        var roundRepo = new Mock<IRoundRepository>();
+        roundRepo.Setup(r => r.GetCurrentLiveAsync("ton", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(round);
+        roundRepo.Setup(r => r.UpdateByPrimaryKeyAsync(round))
+            .ReturnsAsync(true)
+            .Verifiable();
+
+        var clientProxy = new Mock<IClientProxy>();
+        clientProxy.Setup(p => p.SendCoreAsync(
+                "currentRound",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+        var hubClients = new Mock<IHubClients>();
+        hubClients.SetupGet(h => h.All).Returns(clientProxy.Object);
+        var hubContext = new Mock<IHubContext<PredictionHub>>();
+        hubContext.SetupGet(h => h.Clients).Returns(hubClients.Object);
+
+        var sp = new ServiceCollection()
+            .AddSingleton(betRepo.Object)
+            .AddSingleton(roundRepo.Object)
+            .BuildServiceProvider();
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(sp);
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                {"ENV_MASTER_WALLET_ADDRESS", "addr"}
+            }).Build();
+
+        var listener = new TonEventListener(
+            scopeFactory.Object,
+            config,
+            hubContext.Object,
+            NullLogger<TonEventListener>.Instance,
+            new Mock<IHttpClientFactory>().Object);
+
+        var tx = new TonTxDetail(2m, new InMsg("sender", "ton bull"));
+        await listener.ProcessTransactionAsync(tx, CancellationToken.None);
+
+        betRepo.Verify(b => b.InsertAsync(It.IsAny<BetEntity>()), Times.Once);
+        roundRepo.Verify(r => r.UpdateByPrimaryKeyAsync(round), Times.Once);
+        clientProxy.Verify(p => p.SendCoreAsync(
+            "currentRound",
+            It.IsAny<object?[]>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/TonPrediction.Test/TonPrediction.Test.csproj
+++ b/TonPrediction.Test/TonPrediction.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
@@ -18,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\TonPrediction.Application\TonPrediction.Application.csproj" />
     <ProjectReference Include="..\TonPrediction.Infrastructure\TonPrediction.Infrastructure.csproj" />
+    <ProjectReference Include="..\TonPrediction.Api\TonPrediction.Api.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- expose `TonEventListener.ProcessTransactionAsync` for unit testing
- register named HttpClient for TonAPI
- allow internal access to tests
- add unit test covering bet insertion and round update

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6867918f23d88323aa1d207d4eb97dd4