### PR TITLE
feat(round): pre-create next round and lock current

### DIFF
--- a/TonPrediction.Application/Database/Repository/IRoundRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IRoundRepository.cs
@@ -31,6 +31,15 @@ namespace TonPrediction.Application.Database.Repository
             CancellationToken ct = default);
 
         /// <summary>
+        /// 获取当前锁定中的回合。
+        /// </summary>
+        /// <param name="symbol">币种符号。</param>
+        /// <param name="ct">取消令牌。</param>
+        Task<RoundEntity?> GetCurrentLockedAsync(
+            string symbol,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// 获取最近结束的若干回合。
         /// </summary>
         /// <param name="limit">限制数量。</param>

--- a/TonPrediction.Infrastructure/Database/Repository/RoundRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/RoundRepository.cs
@@ -45,6 +45,17 @@ namespace TonPrediction.Infrastructure.Database.Repository
         }
 
         /// <inheritdoc />
+        public async Task<RoundEntity?> GetCurrentLockedAsync(
+            string symbol,
+            CancellationToken ct = default)
+        {
+            return await Db.Queryable<RoundEntity>()
+                .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Locked)
+                .OrderBy(r => r.Id, OrderByType.Desc)
+                .FirstAsync();
+        }
+
+        /// <inheritdoc />
         public async Task<List<RoundEntity>> GetEndedAsync(
             string symbol,
             int limit,


### PR DESCRIPTION
## Summary
- add `GetCurrentLockedAsync` to round repository
- adjust RoundScheduler to lock current round and pre-create the next

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686b2ec7195483239d84f5aa8768f822