### PR TITLE
fix: restore id field in round entity

### DIFF
--- a/TonPrediction.Api/Services/PriceMonitor.cs
+++ b/TonPrediction.Api/Services/PriceMonitor.cs
@@ -92,7 +92,7 @@ namespace TonPrediction.Api.Services
                 var oddsBear = round.BearAmount > 0m ? round.TotalAmount / round.BearAmount : 0m;
                 await _hub.Clients.All.SendAsync("currentRound", new
                 {
-                    roundId = round.Id,
+                    roundId = round.Epoch,
                     lockPrice = round.LockPrice.ToString("F8"),
                     currentPrice = price.ToString("F8"),
                     totalAmount = round.TotalAmount.ToString("F8"),

--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -133,7 +133,7 @@ public class TonEventListener(
 
         await betRepo.InsertAsync(new BetEntity
         {
-            Epoch = round.Id,
+            Epoch = round.Epoch,
             UserAddress = sender,
             Amount = amount,
             Position = position,
@@ -155,7 +155,7 @@ public class TonEventListener(
             "currentRound",
             new
             {
-                roundId = round.Id,
+                roundId = round.Epoch,
                 lockPrice = round.LockPrice.ToString("F8"),
                 currentPrice = round.ClosePrice > 0 ? round.ClosePrice.ToString("F8") : round.LockPrice.ToString("F8"),
                 totalAmount = round.TotalAmount.ToString("F8"),

--- a/TonPrediction.Application/Database/Entities/RoundEntity.cs
+++ b/TonPrediction.Application/Database/Entities/RoundEntity.cs
@@ -12,10 +12,16 @@ namespace TonPrediction.Application.Database.Entities
     {
 
         /// <summary>
-        /// 回合编号。
+        /// 主键编号，通常使用时间戳生成，保证全局唯一。
         /// </summary>
         [SugarColumn(IsPrimaryKey = true, IsIdentity = false, ColumnName = "id")]
         public long Id { get; set; }
+
+        /// <summary>
+        /// 回合序号，从 1 开始按币种独立递增。
+        /// </summary>
+        [SugarColumn(ColumnName = "epoch")]
+        public long Epoch { get; set; }
 
         /// <summary>
         /// 预测币种符号，如 ton、btc、eth。

--- a/TonPrediction.Application/Database/Repository/IRoundRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IRoundRepository.cs
@@ -52,10 +52,10 @@ namespace TonPrediction.Application.Database.Repository
         /// <summary>
         /// 根据编号批量查询回合。
         /// </summary>
-        /// <param name="ids">回合编号集合。</param>
+        /// <param name="epochs">回合序号集合。</param>
         /// <param name="ct">取消令牌。</param>
-        Task<List<RoundEntity>> GetByIdsAsync(
-            long[] ids,
+        Task<List<RoundEntity>> GetByEpochsAsync(
+            long[] epochs,
             CancellationToken ct = default);
     }
 }

--- a/TonPrediction.Application/Services/PredictionService.cs
+++ b/TonPrediction.Application/Services/PredictionService.cs
@@ -28,9 +28,9 @@ public class PredictionService(
         page = page <= 0 ? 1 : page;
         pageSize = pageSize is <= 0 or > 100 ? 10 : pageSize;
         var bets = await _betRepo.GetPagedByAddressAsync(address, status, page, pageSize, ct);
-        var ids = bets.Select(b => b.Epoch).ToArray();
-        var rounds = await _roundRepo.GetByIdsAsync(ids, ct);
-        var map = rounds.ToDictionary(r => r.Id);
+        var epochs = bets.Select(b => b.Epoch).ToArray();
+        var rounds = await _roundRepo.GetByEpochsAsync(epochs, ct);
+        var map = rounds.ToDictionary(r => r.Epoch);
         var list = new List<BetRecordOutput>();
         foreach (var bet in bets)
         {

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -28,7 +28,7 @@ public class RoundService(
         var list = await _roundRepo.GetEndedAsync(symbol, limit, ct);
         return list.Select(r => new RoundHistoryOutput
         {
-            RoundId = r.Id,
+            RoundId = r.Epoch,
             LockPrice = r.LockPrice.ToString("F8"),
             ClosePrice = r.ClosePrice.ToString("F8"),
             TotalAmount = r.TotalAmount.ToString("F8"),
@@ -54,13 +54,14 @@ public class RoundService(
         var latest = await _roundRepo.GetLatestAsync(symbol, ct);
         var intervalSec = _configuration.GetValue<int>("ENV_ROUND_INTERVAL_SEC", 300);
         var startTime = latest?.CloseTime ?? DateTime.UtcNow;
+        var startEpoch = (latest?.Epoch ?? 0) + 1;
         var list = new List<UpcomingRoundOutput>();
         for (var i = 0; i < 2; i++)
         {
             var s = startTime.AddSeconds(intervalSec * i);
             list.Add(new UpcomingRoundOutput
             {
-                RoundId = new DateTimeOffset(s).ToUnixTimeSeconds(),
+                RoundId = startEpoch + i,
                 StartTime = new DateTimeOffset(s).ToUnixTimeSeconds(),
                 EndTime = new DateTimeOffset(s.AddSeconds(intervalSec)).ToUnixTimeSeconds()
             });

--- a/TonPrediction.Infrastructure/Database/Repository/RoundRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/RoundRepository.cs
@@ -29,7 +29,7 @@ namespace TonPrediction.Infrastructure.Database.Repository
         {
             return await Db.Queryable<RoundEntity>()
                 .Where(r => r.Symbol == symbol)
-                .OrderBy(r => r.Id, OrderByType.Desc)
+                .OrderBy(r => r.Epoch, OrderByType.Desc)
                 .FirstAsync();
         }
 
@@ -40,7 +40,7 @@ namespace TonPrediction.Infrastructure.Database.Repository
         {
             return await Db.Queryable<RoundEntity>()
                 .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Live)
-                .OrderBy(r => r.Id, OrderByType.Desc)
+                .OrderBy(r => r.Epoch, OrderByType.Desc)
                 .FirstAsync();
         }
 
@@ -51,7 +51,7 @@ namespace TonPrediction.Infrastructure.Database.Repository
         {
             return await Db.Queryable<RoundEntity>()
                 .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Locked)
-                .OrderBy(r => r.Id, OrderByType.Desc)
+                .OrderBy(r => r.Epoch, OrderByType.Desc)
                 .FirstAsync();
         }
 
@@ -63,16 +63,16 @@ namespace TonPrediction.Infrastructure.Database.Repository
         {
             return await Db.Queryable<RoundEntity>()
                 .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Ended)
-                .OrderBy(r => r.Id, OrderByType.Desc)
+                .OrderBy(r => r.Epoch, OrderByType.Desc)
                 .Take(limit)
                 .ToListAsync();
         }
 
         /// <inheritdoc />
-        public async Task<List<RoundEntity>> GetByIdsAsync(long[] ids, CancellationToken ct = default)
+        public async Task<List<RoundEntity>> GetByEpochsAsync(long[] epochs, CancellationToken ct = default)
         {
             return await Db.Queryable<RoundEntity>()
-                .Where(r => ids.Contains(r.Id))
+                .Where(r => epochs.Contains(r.Epoch))
                 .ToListAsync();
         }
     }

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -29,6 +29,7 @@ public class TonEventListenerTests
         {
             Symbol = "ton",
             Id = 1,
+            Epoch = 1,
             CloseTime = DateTime.UtcNow.AddMinutes(5),
             LockPrice = 1m,
             Status = RoundStatus.Live


### PR DESCRIPTION
## Summary
- restore `Id` as primary key for `RoundEntity`
- keep sequential `Epoch` for each symbol
- set `Id` when creating rounds
- adjust unit tests

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686b4c160a288323942ec3abcd611ac2