### PR TITLE
feat(round): improve scheduler

### DIFF
--- a/TonPrediction.Application/Cache/CacheKeyCollection.cs
+++ b/TonPrediction.Application/Cache/CacheKeyCollection.cs
@@ -28,6 +28,14 @@ namespace TonPrediction.Application.Cache
             $"{AppDomain.CurrentDomain.FriendlyName}lock:round_scheduler";
 
         /// <summary>
+        /// 获取指定币种的 RoundScheduler 锁 key。
+        /// </summary>
+        /// <param name="symbol">币种符号。</param>
+        /// <returns>分布式锁 key。</returns>
+        public static string GetRoundSchedulerLockKey(string symbol) =>
+            $"{AppDomain.CurrentDomain.FriendlyName}lock:round_scheduler:{symbol}";
+
+        /// <summary>
         /// 分布式锁：PriceMonitor。
         /// </summary>
         public static string PriceMonitorLockKey =>

--- a/TonPrediction.Application/Database/Repository/IBetRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IBetRepository.cs
@@ -37,5 +37,14 @@ namespace TonPrediction.Application.Database.Repository
         Task<List<BetEntity>> GetByAddressAsync(
             string address,
             CancellationToken ct = default);
+
+        /// <summary>
+        /// 获取指定回合的全部下注记录。
+        /// </summary>
+        /// <param name="roundId">回合编号。</param>
+        /// <param name="ct">取消令牌。</param>
+        Task<List<BetEntity>> GetByRoundAsync(
+            long roundId,
+            CancellationToken ct = default);
     }
 }

--- a/TonPrediction.Infrastructure/Database/Repository/BetRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/BetRepository.cs
@@ -50,5 +50,15 @@ namespace TonPrediction.Infrastructure.Database.Repository
                 .Where(b => b.UserAddress == address)
                 .ToListAsync();
         }
+
+        /// <inheritdoc />
+        public async Task<List<BetEntity>> GetByRoundAsync(
+            long roundId,
+            CancellationToken ct = default)
+        {
+            return await Db.Queryable<BetEntity>()
+                .Where(b => b.RoundId == roundId)
+                .ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add per-symbol scheduler lock key
- support fetching bets by round
- calculate rewards when a round ends
- run RoundScheduler loop in parallel per symbol

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_686b719c17488323aa318e18c25d0140