### PR TITLE
feat/prediction

### DIFF
--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -86,7 +86,11 @@ public class TonEventListener(
                                 $"/v2/blockchain/transactions/{head.Tx_Hash}",
                                 stoppingToken);
 
-                        await ProcessTransactionAsync(detail!, stoppingToken);
+                        if (detail != null)
+                        {
+                            detail = detail with { Hash = head.Tx_Hash };
+                            await ProcessTransactionAsync(detail, stoppingToken);
+                        }
                     }
                 }
             }
@@ -138,7 +142,8 @@ public class TonEventListener(
             Amount = amount,
             Position = position,
             Claimed = false,
-            Reward = 0m
+            Reward = 0m,
+            TxHash = tx.Hash
         });
 
         round.TotalAmount += amount;
@@ -186,9 +191,11 @@ public record SseTxHead(string Account_Id, ulong Lt, string Tx_Hash);
 /// </summary>
 /// <param name="Amount">交易金额（nanoTON 已转普通 TON）</param>
 /// <param name="In_Message"></param>
+/// <param name="Hash">交易哈希。</param>
 public record TonTxDetail(
     decimal Amount,
-    InMsg In_Message);
+    InMsg In_Message,
+    string Hash);
 
 /// <summary>
 /// 

--- a/TonPrediction.Application/Database/Entities/BetEntity.cs
+++ b/TonPrediction.Application/Database/Entities/BetEntity.cs
@@ -50,5 +50,11 @@ namespace TonPrediction.Application.Database.Entities
         /// </summary>
         [SugarColumn(ColumnName = "reward", ColumnDataType = "decimal(18,8)")]
         public decimal Reward { get; set; }
+
+        /// <summary>
+        /// 下注交易哈希。
+        /// </summary>
+        [SugarColumn(ColumnName = "tx_hash")]
+        public string TxHash { get; set; } = string.Empty;
     }
 }

--- a/TonPrediction.Application/Output/BetRecordOutput.cs
+++ b/TonPrediction.Application/Output/BetRecordOutput.cs
@@ -48,6 +48,11 @@ public class BetRecordOutput
     public bool Claimed { get; set; }
 
     /// <summary>
+    /// 下注交易哈希。
+    /// </summary>
+    public string TxHash { get; set; } = string.Empty;
+
+    /// <summary>
     /// 结果。
     /// </summary>
     public BetResult Result { get; set; }

--- a/TonPrediction.Application/Services/PredictionService.cs
+++ b/TonPrediction.Application/Services/PredictionService.cs
@@ -59,6 +59,7 @@ public class PredictionService(
                 ClosePrice = round.ClosePrice.ToString("F8"),
                 Reward = bet.Reward.ToString("F8"),
                 Claimed = bet.Claimed,
+                TxHash = bet.TxHash,
                 Result = result
             };
             list.Add(output);

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -35,8 +35,10 @@ public class TonEventListenerTests
             Status = RoundStatus.Live
         };
 
+        BetEntity? inserted = null;
         var betRepo = new Mock<IBetRepository>();
         betRepo.Setup(b => b.InsertAsync(It.IsAny<BetEntity>()))
+            .Callback<BetEntity>(b => inserted = b)
             .ReturnsAsync(new BetEntity())
             .Verifiable();
 
@@ -82,7 +84,7 @@ public class TonEventListenerTests
             new Mock<IHttpClientFactory>().Object,
             Mock.Of<IDistributedLock>());
 
-        var tx = new TonTxDetail(2m, new InMsg("sender", "ton bull"));
+        var tx = new TonTxDetail(2m, new InMsg("sender", "ton bull"), "hash");
         await listener.ProcessTransactionAsync(tx, CancellationToken.None);
 
         betRepo.Verify(b => b.InsertAsync(It.IsAny<BetEntity>()), Times.Once);
@@ -91,5 +93,7 @@ public class TonEventListenerTests
             "currentRound",
             It.IsAny<object?[]>(),
             It.IsAny<CancellationToken>()), Times.Once);
+
+        Assert.Equal("hash", inserted?.TxHash);
     }
 }


### PR DESCRIPTION
## Summary
- add `TxHash` column to BetEntity and output
- persist tx hash when processing TON transactions
- include transaction hash in prediction service output
- verify tx hash is stored in TonEventListener tests

## Testing
- `dotnet build -c Release`
- `dotnet test --no-build`
- `dotnet format --verify-no-changes`


------
https://chatgpt.com/codex/tasks/task_e_686b7c66ff308323a47a42a9ebf9040c