### PR TITLE
feat(listener): persist last lt state

### DIFF
--- a/TonPrediction.Application/Cache/CacheKeyCollection.cs
+++ b/TonPrediction.Application/Cache/CacheKeyCollection.cs
@@ -46,5 +46,11 @@ namespace TonPrediction.Application.Cache
         /// </summary>
         public static string TonEventListenerLockKey =>
             $"{AppDomain.CurrentDomain.FriendlyName}lock:ton_event_listener";
+
+        /// <summary>
+        /// TonEventListener 状态键。
+        /// </summary>
+        public static string TonEventListenerLastLtKey =>
+            $"{AppDomain.CurrentDomain.FriendlyName}state:ton_event_listener_lt";
     }
 }

--- a/TonPrediction.Application/Database/Entities/StateEntity.cs
+++ b/TonPrediction.Application/Database/Entities/StateEntity.cs
@@ -1,0 +1,23 @@
+using SqlSugar;
+
+namespace TonPrediction.Application.Database.Entities
+{
+    /// <summary>
+    /// 用于存储应用状态的简单键值实体。
+    /// </summary>
+    [SugarTable("state")]
+    public class StateEntity
+    {
+        /// <summary>
+        /// 状态键。
+        /// </summary>
+        [SugarColumn(IsPrimaryKey = true, ColumnName = "key", Length = 64)]
+        public string Key { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 状态值。
+        /// </summary>
+        [SugarColumn(ColumnName = "value", Length = 256)]
+        public string Value { get; set; } = string.Empty;
+    }
+}

--- a/TonPrediction.Application/Database/Repository/IStateRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IStateRepository.cs
@@ -1,0 +1,27 @@
+using TonPrediction.Application.Database.Entities;
+using QYQ.Base.SqlSugar;
+using QYQ.Base.Common.IOCExtensions;
+
+namespace TonPrediction.Application.Database.Repository;
+
+/// <summary>
+/// 应用状态仓库接口。
+/// </summary>
+public interface IStateRepository : IBaseRepository<StateEntity>, ITransientDependency
+{
+    /// <summary>
+    /// 根据键获取值。
+    /// </summary>
+    /// <param name="key">键。</param>
+    /// <param name="ct">取消令牌。</param>
+    /// <returns>值或 null。</returns>
+    Task<string?> GetValueAsync(string key, CancellationToken ct = default);
+
+    /// <summary>
+    /// 设置键值。
+    /// </summary>
+    /// <param name="key">键。</param>
+    /// <param name="value">值。</param>
+    /// <param name="ct">取消令牌。</param>
+    Task SetValueAsync(string key, string value, CancellationToken ct = default);
+}

--- a/TonPrediction.Infrastructure/Database/Migrations/InitMigration.cs
+++ b/TonPrediction.Infrastructure/Database/Migrations/InitMigration.cs
@@ -18,6 +18,7 @@ namespace TonPrediction.Infrastructure.Database.Migrations
             db.CodeFirst.InitTables<BetEntity>();
             db.CodeFirst.InitTables<PriceSnapshotEntity>();
             db.CodeFirst.InitTables<ClaimEntity>();
+            db.CodeFirst.InitTables<StateEntity>();
         }
     }
 }

--- a/TonPrediction.Infrastructure/Database/Repository/StateRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/StateRepository.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using QYQ.Base.SqlSugar;
+using SqlSugar;
+using TonPrediction.Application.Database.Config;
+using TonPrediction.Application.Database.Entities;
+using TonPrediction.Application.Database.Repository;
+
+namespace TonPrediction.Infrastructure.Database.Repository;
+
+/// <summary>
+/// 应用状态仓库实现。
+/// </summary>
+/// <param name="logger">日志组件。</param>
+/// <param name="options">数据库配置。</param>
+/// <param name="dbType">数据库类型。</param>
+public class StateRepository(
+    ILogger<StateRepository> logger,
+    IOptionsMonitor<DatabaseConfig> options,
+    DbType dbType = DbType.MySql)
+    : BaseRepository<StateEntity>(logger, options.CurrentValue.Default, dbType),
+        IStateRepository
+{
+    /// <inheritdoc />
+    public async Task<string?> GetValueAsync(string key, CancellationToken ct = default)
+    {
+        var entity = await Db.Queryable<StateEntity>()
+            .Where(s => s.Key == key)
+            .FirstAsync();
+        return entity?.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task SetValueAsync(string key, string value, CancellationToken ct = default)
+    {
+        var exist = await Db.Queryable<StateEntity>()
+            .Where(s => s.Key == key)
+            .FirstAsync();
+        if (exist == null)
+        {
+            await Db.Insertable(new StateEntity { Key = key, Value = value })
+                .ExecuteCommandAsync();
+        }
+        else
+        {
+            exist.Value = value;
+            await Db.Updateable(exist).ExecuteCommandAsync();
+        }
+    }
+}

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -63,9 +63,11 @@ public class TonEventListenerTests
         var hubContext = new Mock<IHubContext<PredictionHub>>();
         hubContext.SetupGet(h => h.Clients).Returns(hubClients.Object);
 
+        var stateRepo = new Mock<IStateRepository>();
         var sp = new ServiceCollection()
             .AddSingleton(betRepo.Object)
             .AddSingleton(roundRepo.Object)
+            .AddSingleton(stateRepo.Object)
             .BuildServiceProvider();
         var scope = new Mock<IServiceScope>();
         scope.SetupGet(s => s.ServiceProvider).Returns(sp);
@@ -132,9 +134,11 @@ public class TonEventListenerTests
         var hubContext = new Mock<IHubContext<PredictionHub>>();
         hubContext.SetupGet(h => h.Clients).Returns(hubClients.Object);
 
+        var stateRepo = new Mock<IStateRepository>();
         var sp = new ServiceCollection()
             .AddSingleton(betRepo.Object)
             .AddSingleton(roundRepo.Object)
+            .AddSingleton(stateRepo.Object)
             .BuildServiceProvider();
         var scope = new Mock<IServiceScope>();
         scope.SetupGet(s => s.ServiceProvider).Returns(sp);


### PR DESCRIPTION
## Summary
- store TonEventListener last processed LT in new `state` table
- add `StateRepository` and repository interfaces
- expose `TonEventListenerLastLtKey` constant
- use persisted LT to recover missed transactions
- update unit tests

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_686b8fc5332c8323917b4bb958629cfe