### PR TITLE
feat(wallet): implement TonWalletService

### DIFF
--- a/TonPrediction.Api/Program.cs
+++ b/TonPrediction.Api/Program.cs
@@ -19,7 +19,8 @@ builder.Services.AddSignalR();
 builder.Services.AddHttpClient();
 builder.Services.AddHttpClient("TonApi", c =>
 {
-    c.BaseAddress = new Uri("https://tonapi.io");
+    var baseUrl = builder.Configuration["TonApi:BaseUrl"] ?? "https://tonapi.io";
+    c.BaseAddress = new Uri(baseUrl);
 });
 builder.Services.AddMultipleService("^TonPrediction");
 builder.Services.AddSingleton<ApplicationDbContext>();

--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -29,7 +29,7 @@ public class TonEventListener(
     private readonly string _walletAddress = configuration["ENV_MASTER_WALLET_ADDRESS"] ?? string.Empty;
     private ulong _lastLt;
     private const string SseUrlTemplate =
-        "https://tonapi.io/v2/sse/accounts/transactions?accounts={0}";
+        "/v2/sse/accounts/transactions?accounts={0}";
     private static readonly Regex CommentRegex = new(@"^\s*(\w+)\s+(bull|bear)\s*$", RegexOptions.IgnoreCase);
 
     /// <summary>

--- a/TonPrediction.Api/appsettings.Development.json
+++ b/TonPrediction.Api/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "TonApi": {
+    "BaseUrl": "https://testnet.tonapi.io"
   }
 }

--- a/TonPrediction.Api/appsettings.json
+++ b/TonPrediction.Api/appsettings.json
@@ -43,5 +43,12 @@
     "Database": 0
   },
   "ENV_ROUND_INTERVAL_SEC": "300",
-  "Symbols": [ "ton", "btc", "eth" ]
+  "Symbols": [
+    "ton",
+    "btc",
+    "eth"
+  ],
+  "TonApi": {
+    "BaseUrl": "https://tonapi.io"
+  }
 }

--- a/TonPrediction.Test/TonWalletServiceTests.cs
+++ b/TonPrediction.Test/TonWalletServiceTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TonPrediction.Infrastructure.Services;
+using Xunit;
+
+namespace TonPrediction.Test;
+
+/// <summary>
+/// TonWalletService 单元测试。
+/// </summary>
+public class TonWalletServiceTests
+{
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"hash\":\"h\",\"lt\":1}")
+            };
+            return Task.FromResult(resp);
+        }
+    }
+
+    private sealed class FakeFactory(HttpClient client) : IHttpClientFactory
+    {
+        private readonly HttpClient _client = client;
+        public HttpClient CreateClient(string name) => _client;
+    }
+
+    [Fact]
+    public async Task TransferAsync_CallsTonApi()
+    {
+        var handler = new FakeHandler();
+        var client = new HttpClient(handler) { BaseAddress = new System.Uri("https://tonapi.io") };
+        var factory = new FakeFactory(client);
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
+        {
+            new KeyValuePair<string,string>("ENV_MASTER_WALLET_ADDRESS","master")
+        }).Build();
+        var service = new TonWalletService(config, factory, NullLogger<TonWalletService>.Instance);
+
+        var result = await service.TransferAsync("addr", 1m);
+
+        Assert.Equal("h", result.TxHash);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/v2/blockchain/accounts/master/transfer", handler.Request!.RequestUri!.AbsolutePath);
+        var body = JsonDocument.Parse(await handler.Request.Content!.ReadAsStringAsync());
+        Assert.Equal("addr", body.RootElement.GetProperty("to").GetString());
+    }
+}


### PR DESCRIPTION
## Summary
- read TonApi base URL from configuration
- use testnet API URL in Development environment
- complete TonWalletService with HTTP calls
- update TonEventListener to use relative SSE path
- add TonWalletService unit tests

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686b9f3aadd0832391d1e8d2d0121252