### PR TITLE
feat: typed SignalR messages

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -47,8 +47,8 @@
 | `bearAmount` | string(decimal) | 押 **下跌** 的金额                       |
 | `rewardPool`   | string(decimal) | 扣除手续费后的可分配奖金池               |
 | `endTime`      | int             | 回合结束时间（Unix 秒）                  |
-| `bullOdds`  | string(decimal) | 上涨赔率 = `totalAmount / upAmount`      |
-| `bearOdds` | string(decimal) | 下跌赔率 = `totalAmount / downAmount`    |
+| `bullOdds`  | string(decimal) | 上涨赔率 = `totalAmount / bullAmount`    |
+| `bearOdds` | string(decimal) | 下跌赔率 = `totalAmount / bearAmount`   |
 | `status`       | enum            | `upcoming` |
 
 **示例：**
@@ -105,12 +105,12 @@
 | `lockPrice`   | string(decimal) | 锁定价格           |
 | `closePrice`  | string(decimal) | 收盘价格           |
 | `totalAmount` | string(decimal) | 总下注金额         |
-| `upAmount`    | string(decimal) | 押 **上涨** 的金额 |
-| `downAmount`  | string(decimal) | 押 **下跌** 的金额 |
+| `bullAmount`  | string(decimal) | 押 **上涨** 的金额 |
+| `bearAmount`  | string(decimal) | 押 **下跌** 的金额 |
 | `rewardPool`  | string(decimal) | 奖金池（扣手续费） |
 | `endTime`     | int             | 结束时间           |
-| `oddsUp`      | string(decimal) | 上涨赔率           |
-| `oddsDown`    | string(decimal) | 下跌赔率           |
+| `bullOdds`    | string(decimal) | 上涨赔率           |
+| `bearOdds`    | string(decimal) | 下跌赔率           |
 
 **示例：**
 
@@ -121,12 +121,12 @@
     "lockPrice": "308.85000000",
     "closePrice": "309.75000000",
     "totalAmount": "1800.00000000",
-    "upAmount": "1000.00000000",
-    "downAmount": "800.00000000",
+    "bullAmount": "1000.00000000",
+    "bearAmount": "800.00000000",
     "rewardPool": "1746.00000000",
     "endTime": 1709999999,
-    "oddsUp": "1.80000000",
-    "oddsDown": "2.25000000"
+    "bullOdds": "1.80000000",
+    "bearOdds": "2.25000000"
   }
 ]
 ```

--- a/TonPrediction.Api/Services/RoundScheduler.cs
+++ b/TonPrediction.Api/Services/RoundScheduler.cs
@@ -10,6 +10,7 @@ using TonPrediction.Application.Enums;
 using PancakeSwap.Api.Hubs;
 using TonPrediction.Application.Services.Interface;
 using TonPrediction.Application.Cache;
+using TonPrediction.Application.Output;
 
 namespace TonPrediction.Api.Services
 {
@@ -130,7 +131,10 @@ namespace TonPrediction.Api.Services
                 }
 
                 await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = closePrice });
-                await _hub.Clients.All.SendAsync("roundEnded", new { roundId = locked.Epoch }, token);
+                await _hub.Clients.All.SendAsync("roundEnded", new RoundEndedOutput
+                {
+                    RoundId = locked.Epoch
+                }, token);
             }
 
             // 获取当前可下注的回合
@@ -155,7 +159,10 @@ namespace TonPrediction.Api.Services
                     };
                     await roundRepo.InsertAsync(genesisLocked);
                     await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = startPrice });
-                    await _hub.Clients.All.SendAsync("roundLocked", new { roundId = genesisLocked.Epoch }, token);
+                    await _hub.Clients.All.SendAsync("roundLocked", new RoundLockedOutput
+                    {
+                        RoundId = genesisLocked.Epoch
+                    }, token);
 
                     var liveRound = new RoundEntity
                     {
@@ -169,19 +176,19 @@ namespace TonPrediction.Api.Services
                     };
                     await roundRepo.InsertAsync(liveRound);
                     await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = startPrice });
-                    await _hub.Clients.All.SendAsync("currentRound", new
+                    await _hub.Clients.All.SendAsync("currentRound", new CurrentRoundOutput
                     {
-                        roundId = liveRound.Epoch,
-                        lockPrice = liveRound.LockPrice.ToString("F8"),
-                        currentPrice = liveRound.LockPrice.ToString("F8"),
-                        totalAmount = liveRound.TotalAmount.ToString("F8"),
-                        bullAmount = liveRound.BullAmount.ToString("F8"),
-                        bearAmount = liveRound.BearAmount.ToString("F8"),
-                        rewardPool = liveRound.RewardAmount.ToString("F8"),
-                        endTime = new DateTimeOffset(liveRound.CloseTime).ToUnixTimeSeconds(),
-                        oddsUp = "0",
-                        oddsDown = "0",
-                        status = liveRound.Status
+                        RoundId = liveRound.Epoch,
+                        LockPrice = liveRound.LockPrice.ToString("F8"),
+                        CurrentPrice = liveRound.LockPrice.ToString("F8"),
+                        TotalAmount = liveRound.TotalAmount.ToString("F8"),
+                        BullAmount = liveRound.BullAmount.ToString("F8"),
+                        BearAmount = liveRound.BearAmount.ToString("F8"),
+                        RewardPool = liveRound.RewardAmount.ToString("F8"),
+                        EndTime = new DateTimeOffset(liveRound.CloseTime).ToUnixTimeSeconds(),
+                        BullOdds = "0",
+                        BearOdds = "0",
+                        Status = liveRound.Status
                     }, token);
                 }
                 else
@@ -198,19 +205,19 @@ namespace TonPrediction.Api.Services
                     };
                     await roundRepo.InsertAsync(firstRound);
                     await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = startPrice });
-                    await _hub.Clients.All.SendAsync("currentRound", new
+                    await _hub.Clients.All.SendAsync("currentRound", new CurrentRoundOutput
                     {
-                        roundId = firstRound.Epoch,
-                        lockPrice = firstRound.LockPrice.ToString("F8"),
-                        currentPrice = firstRound.LockPrice.ToString("F8"),
-                        totalAmount = firstRound.TotalAmount.ToString("F8"),
-                        upAmount = firstRound.BullAmount.ToString("F8"),
-                        downAmount = firstRound.BearAmount.ToString("F8"),
-                        rewardPool = firstRound.RewardAmount.ToString("F8"),
-                        endTime = new DateTimeOffset(firstRound.CloseTime).ToUnixTimeSeconds(),
-                        oddsUp = "0",
-                        oddsDown = "0",
-                        status = firstRound.Status
+                        RoundId = firstRound.Epoch,
+                        LockPrice = firstRound.LockPrice.ToString("F8"),
+                        CurrentPrice = firstRound.LockPrice.ToString("F8"),
+                        TotalAmount = firstRound.TotalAmount.ToString("F8"),
+                        BullAmount = firstRound.BullAmount.ToString("F8"),
+                        BearAmount = firstRound.BearAmount.ToString("F8"),
+                        RewardPool = firstRound.RewardAmount.ToString("F8"),
+                        EndTime = new DateTimeOffset(firstRound.CloseTime).ToUnixTimeSeconds(),
+                        BullOdds = "0",
+                        BearOdds = "0",
+                        Status = firstRound.Status
                     }, token);
                 }
 
@@ -227,7 +234,10 @@ namespace TonPrediction.Api.Services
                 live.Status = RoundStatus.Locked;
                 await roundRepo.UpdateByPrimaryKeyAsync(live);
                 await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = lockPrice });
-                await _hub.Clients.All.SendAsync("roundLocked", new { roundId = live.Epoch }, token);
+                await _hub.Clients.All.SendAsync("roundLocked", new RoundLockedOutput
+                {
+                    RoundId = live.Epoch
+                }, token);
 
                 var nextPrice = lockPrice;
                 var nextRound = new RoundEntity
@@ -242,19 +252,19 @@ namespace TonPrediction.Api.Services
                 };
                 await roundRepo.InsertAsync(nextRound);
                 await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = nextPrice });
-                await _hub.Clients.All.SendAsync("currentRound", new
+                await _hub.Clients.All.SendAsync("currentRound", new CurrentRoundOutput
                 {
-                    roundId = nextRound.Epoch,
-                    lockPrice = nextRound.LockPrice.ToString("F8"),
-                    currentPrice = nextRound.LockPrice.ToString("F8"),
-                    totalAmount = nextRound.TotalAmount.ToString("F8"),
-                    upAmount = nextRound.BullAmount.ToString("F8"),
-                    downAmount = nextRound.BearAmount.ToString("F8"),
-                    rewardPool = nextRound.RewardAmount.ToString("F8"),
-                    endTime = new DateTimeOffset(nextRound.CloseTime).ToUnixTimeSeconds(),
-                    oddsUp = "0",
-                    oddsDown = "0",
-                    status = nextRound.Status
+                    RoundId = nextRound.Epoch,
+                    LockPrice = nextRound.LockPrice.ToString("F8"),
+                    CurrentPrice = nextRound.LockPrice.ToString("F8"),
+                    TotalAmount = nextRound.TotalAmount.ToString("F8"),
+                    BullAmount = nextRound.BullAmount.ToString("F8"),
+                    BearAmount = nextRound.BearAmount.ToString("F8"),
+                    RewardPool = nextRound.RewardAmount.ToString("F8"),
+                    EndTime = new DateTimeOffset(nextRound.CloseTime).ToUnixTimeSeconds(),
+                    BullOdds = "0",
+                    BearOdds = "0",
+                    Status = nextRound.Status
                 }, token);
             }
         }

--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -4,6 +4,7 @@ using PancakeSwap.Api.Hubs;
 using TonPrediction.Application.Database.Entities;
 using TonPrediction.Application.Database.Repository;
 using TonPrediction.Application.Enums;
+using TonPrediction.Application.Output;
 using TonPrediction.Application.Services.Interface;
 using TonPrediction.Application.Cache;
 using System.Text.RegularExpressions;
@@ -212,19 +213,19 @@ public class TonEventListener(
 
         await _hub.Clients.All.SendAsync(
             "currentRound",
-            new
+            new CurrentRoundOutput
             {
-                roundId = round.Epoch,
-                lockPrice = round.LockPrice.ToString("F8"),
-                currentPrice = round.ClosePrice > 0 ? round.ClosePrice.ToString("F8") : round.LockPrice.ToString("F8"),
-                totalAmount = round.TotalAmount.ToString("F8"),
-                upAmount = round.BullAmount.ToString("F8"),
-                downAmount = round.BearAmount.ToString("F8"),
-                rewardPool = round.RewardAmount.ToString("F8"),
-                endTime = new DateTimeOffset(round.CloseTime).ToUnixTimeSeconds(),
-                oddsUp = oddsBull.ToString("F8"),
-                oddsDown = oddsBear.ToString("F8"),
-                status = round.Status
+                RoundId = round.Epoch,
+                LockPrice = round.LockPrice.ToString("F8"),
+                CurrentPrice = round.ClosePrice > 0 ? round.ClosePrice.ToString("F8") : round.LockPrice.ToString("F8"),
+                TotalAmount = round.TotalAmount.ToString("F8"),
+                BullAmount = round.BullAmount.ToString("F8"),
+                BearAmount = round.BearAmount.ToString("F8"),
+                RewardPool = round.RewardAmount.ToString("F8"),
+                EndTime = new DateTimeOffset(round.CloseTime).ToUnixTimeSeconds(),
+                BullOdds = oddsBull.ToString("F8"),
+                BearOdds = oddsBear.ToString("F8"),
+                Status = round.Status
             }, ct);
     }
 

--- a/TonPrediction.Application/Output/ChartDataOutput.cs
+++ b/TonPrediction.Application/Output/ChartDataOutput.cs
@@ -1,0 +1,19 @@
+using TonPrediction.Application.Enums;
+
+namespace TonPrediction.Application.Output;
+
+/// <summary>
+/// 价格走势图推送信息。
+/// </summary>
+public class ChartDataOutput
+{
+    /// <summary>
+    /// 时间戳数组（Unix 秒，升序）。
+    /// </summary>
+    public long[] Timestamps { get; set; } = Array.Empty<long>();
+
+    /// <summary>
+    /// 价格数组，对应每个时间点的价格。
+    /// </summary>
+    public string[] Prices { get; set; } = Array.Empty<string>();
+}

--- a/TonPrediction.Application/Output/CurrentRoundOutput.cs
+++ b/TonPrediction.Application/Output/CurrentRoundOutput.cs
@@ -28,14 +28,14 @@ public class CurrentRoundOutput
     public string TotalAmount { get; set; } = string.Empty;
 
     /// <summary>
-    /// 押涨金额。
+    /// 押看涨金额。
     /// </summary>
-    public string UpAmount { get; set; } = string.Empty;
+    public string BullAmount { get; set; } = string.Empty;
 
     /// <summary>
-    /// 押跌金额。
+    /// 押看跌金额。
     /// </summary>
-    public string DownAmount { get; set; } = string.Empty;
+    public string BearAmount { get; set; } = string.Empty;
 
     /// <summary>
     /// 奖金池。
@@ -48,14 +48,14 @@ public class CurrentRoundOutput
     public long EndTime { get; set; }
 
     /// <summary>
-    /// 上涨赔率。
+    /// 看涨赔率。
     /// </summary>
-    public string OddsUp { get; set; } = string.Empty;
+    public string BullOdds { get; set; } = string.Empty;
 
     /// <summary>
-    /// 下跌赔率。
+    /// 看跌赔率。
     /// </summary>
-    public string OddsDown { get; set; } = string.Empty;
+    public string BearOdds { get; set; } = string.Empty;
 
     /// <summary>
     /// 回合状态。

--- a/TonPrediction.Application/Output/RoundEndedOutput.cs
+++ b/TonPrediction.Application/Output/RoundEndedOutput.cs
@@ -1,0 +1,12 @@
+namespace TonPrediction.Application.Output;
+
+/// <summary>
+/// 回合结束推送信息。
+/// </summary>
+public class RoundEndedOutput
+{
+    /// <summary>
+    /// 已结束回合的编号。
+    /// </summary>
+    public long RoundId { get; set; }
+}

--- a/TonPrediction.Application/Output/RoundHistoryOutput.cs
+++ b/TonPrediction.Application/Output/RoundHistoryOutput.cs
@@ -28,14 +28,14 @@ public class RoundHistoryOutput
     public string TotalAmount { get; set; } = string.Empty;
 
     /// <summary>
-    /// 押涨金额。
+    /// 押看涨金额。
     /// </summary>
-    public string UpAmount { get; set; } = string.Empty;
+    public string BullAmount { get; set; } = string.Empty;
 
     /// <summary>
-    /// 押跌金额。
+    /// 押看跌金额。
     /// </summary>
-    public string DownAmount { get; set; } = string.Empty;
+    public string BearAmount { get; set; } = string.Empty;
 
     /// <summary>
     /// 奖金池。
@@ -48,12 +48,12 @@ public class RoundHistoryOutput
     public long EndTime { get; set; }
 
     /// <summary>
-    /// 上涨赔率。
+    /// 看涨赔率。
     /// </summary>
-    public string OddsUp { get; set; } = string.Empty;
+    public string BullOdds { get; set; } = string.Empty;
 
     /// <summary>
-    /// 下跌赔率。
+    /// 看跌赔率。
     /// </summary>
-    public string OddsDown { get; set; } = string.Empty;
+    public string BearOdds { get; set; } = string.Empty;
 }

--- a/TonPrediction.Application/Output/RoundLockedOutput.cs
+++ b/TonPrediction.Application/Output/RoundLockedOutput.cs
@@ -1,0 +1,12 @@
+namespace TonPrediction.Application.Output;
+
+/// <summary>
+/// 回合锁定推送信息。
+/// </summary>
+public class RoundLockedOutput
+{
+    /// <summary>
+    /// 锁定的回合编号。
+    /// </summary>
+    public long RoundId { get; set; }
+}

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -32,12 +32,12 @@ public class RoundService(
             LockPrice = r.LockPrice.ToString("F8"),
             ClosePrice = r.ClosePrice.ToString("F8"),
             TotalAmount = r.TotalAmount.ToString("F8"),
-            UpAmount = r.BullAmount.ToString("F8"),
-            DownAmount = r.BearAmount.ToString("F8"),
+            BullAmount = r.BullAmount.ToString("F8"),
+            BearAmount = r.BearAmount.ToString("F8"),
             RewardPool = r.RewardAmount.ToString("F8"),
             EndTime = new DateTimeOffset(r.CloseTime).ToUnixTimeSeconds(),
-            OddsUp = r.BullAmount > 0m ? (r.TotalAmount / r.BullAmount).ToString("F8") : "0",
-            OddsDown = r.BearAmount > 0m ? (r.TotalAmount / r.BearAmount).ToString("F8") : "0"
+            BullOdds = r.BullAmount > 0m ? (r.TotalAmount / r.BullAmount).ToString("F8") : "0",
+            BearOdds = r.BearAmount > 0m ? (r.TotalAmount / r.BearAmount).ToString("F8") : "0"
         }).ToList();
     }
 


### PR DESCRIPTION
## Summary
- add output DTOs for SignalR events
- refactor SignalR services to send strongly typed messages
- rename up/down fields to bull/bear
- include odds in `currentRound` response
- update API docs

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686c806059ec8323a07b592e38a939d1