### PR TITLE
feat(api): unify SignalR push

### DIFF
--- a/TonPrediction.Api/Services/PredictionHubService.cs
+++ b/TonPrediction.Api/Services/PredictionHubService.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.SignalR;
+using PancakeSwap.Api.Hubs;
+using TonPrediction.Application.Database.Entities;
+using TonPrediction.Application.Output;
+using TonPrediction.Application.Services.Interface;
+
+namespace TonPrediction.Api.Services;
+
+/// <summary>
+/// SignalR 推送实现。
+/// </summary>
+public class PredictionHubService(IHubContext<PredictionHub> hub) : IPredictionHubService
+{
+    private readonly IHubContext<PredictionHub> _hub = hub;
+
+    /// <inheritdoc />
+    public Task PushCurrentRoundAsync(RoundEntity round, decimal currentPrice, CancellationToken ct = default)
+    {
+        var oddsBull = round.BullAmount > 0m ? round.TotalAmount / round.BullAmount : 0m;
+        var oddsBear = round.BearAmount > 0m ? round.TotalAmount / round.BearAmount : 0m;
+        var output = new CurrentRoundOutput
+        {
+            RoundId = round.Epoch,
+            LockPrice = round.LockPrice.ToString("F8"),
+            CurrentPrice = currentPrice.ToString("F8"),
+            TotalAmount = round.TotalAmount.ToString("F8"),
+            BullAmount = round.BullAmount.ToString("F8"),
+            BearAmount = round.BearAmount.ToString("F8"),
+            RewardPool = round.RewardAmount.ToString("F8"),
+            EndTime = new DateTimeOffset(round.CloseTime).ToUnixTimeSeconds(),
+            BullOdds = oddsBull.ToString("F8"),
+            BearOdds = oddsBear.ToString("F8"),
+            Status = round.Status
+        };
+        return _hub.Clients.All.SendAsync("currentRound", output, ct);
+    }
+
+    /// <inheritdoc />
+    public Task PushRoundStartedAsync(long roundId, CancellationToken ct = default) =>
+        _hub.Clients.All.SendAsync("roundStarted", new RoundStartedOutput { RoundId = roundId }, ct);
+
+    /// <inheritdoc />
+    public Task PushRoundLockedAsync(long roundId, CancellationToken ct = default) =>
+        _hub.Clients.All.SendAsync("roundLocked", new RoundLockedOutput { RoundId = roundId }, ct);
+
+    /// <inheritdoc />
+    public Task PushSettlementStartedAsync(long roundId, CancellationToken ct = default) =>
+        _hub.Clients.All.SendAsync("settlementStarted", new SettlementStartedOutput { RoundId = roundId }, ct);
+
+    /// <inheritdoc />
+    public Task PushRoundEndedAsync(long roundId, CancellationToken ct = default) =>
+        _hub.Clients.All.SendAsync("roundEnded", new RoundEndedOutput { RoundId = roundId }, ct);
+
+    /// <inheritdoc />
+    public Task PushSettlementEndedAsync(long roundId, CancellationToken ct = default) =>
+        _hub.Clients.All.SendAsync("settlementEnded", new SettlementEndedOutput { RoundId = roundId }, ct);
+}

--- a/TonPrediction.Application/Services/Interface/IPredictionHubService.cs
+++ b/TonPrediction.Application/Services/Interface/IPredictionHubService.cs
@@ -1,0 +1,55 @@
+using System.Threading;
+using System.Threading.Tasks;
+using QYQ.Base.Common.IOCExtensions;
+using TonPrediction.Application.Database.Entities;
+
+namespace TonPrediction.Application.Services.Interface;
+
+/// <summary>
+/// SignalR 推送服务接口。
+/// </summary>
+public interface IPredictionHubService : ITransientDependency
+{
+    /// <summary>
+    /// 推送当前回合信息。
+    /// </summary>
+    /// <param name="round">当前回合实体。</param>
+    /// <param name="currentPrice">最新价格。</param>
+    /// <param name="ct">取消令牌。</param>
+    Task PushCurrentRoundAsync(RoundEntity round, decimal currentPrice, CancellationToken ct = default);
+
+    /// <summary>
+    /// 推送回合开始消息。
+    /// </summary>
+    /// <param name="roundId">回合编号。</param>
+    /// <param name="ct">取消令牌。</param>
+    Task PushRoundStartedAsync(long roundId, CancellationToken ct = default);
+
+    /// <summary>
+    /// 推送回合锁定消息。
+    /// </summary>
+    /// <param name="roundId">回合编号。</param>
+    /// <param name="ct">取消令牌。</param>
+    Task PushRoundLockedAsync(long roundId, CancellationToken ct = default);
+
+    /// <summary>
+    /// 推送结算开始消息。
+    /// </summary>
+    /// <param name="roundId">回合编号。</param>
+    /// <param name="ct">取消令牌。</param>
+    Task PushSettlementStartedAsync(long roundId, CancellationToken ct = default);
+
+    /// <summary>
+    /// 推送回合结束消息。
+    /// </summary>
+    /// <param name="roundId">回合编号。</param>
+    /// <param name="ct">取消令牌。</param>
+    Task PushRoundEndedAsync(long roundId, CancellationToken ct = default);
+
+    /// <summary>
+    /// 推送结算结束消息。
+    /// </summary>
+    /// <param name="roundId">回合编号。</param>
+    /// <param name="ct">取消令牌。</param>
+    Task PushSettlementEndedAsync(long roundId, CancellationToken ct = default);
+}


### PR DESCRIPTION
## Summary
- add `IPredictionHubService` abstraction for SignalR broadcasts
- implement `PredictionHubService`
- refactor background services to use the notifier
- update unit tests

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686c8829d5a88323b8a70aa198cf2d01