### PR TITLE
feat(round): return id and epoch

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -43,7 +43,7 @@ hub.on("roundEnded", data => { /* ... */ });
 await hub.start();
 ```
 
-> **说明**：所有 `roundId` 字段均表示回合期次（epoch）。
+> **说明**：回合相关响应均同时包含 `id` 与 `epoch` 字段，`id` 用于后续业务请求，`epoch` 用于展示回合期次。
 ------
 
 ## 1️⃣ 当前回合（`currentRound` • WS 推送）
@@ -54,7 +54,8 @@ await hub.start();
 
 | 字段名         | 类型            | 说明                                     |
 | -------------- | --------------- | ---------------------------------------- |
-| `roundId`      | int             | 期次（Epoch）                                 |
+| `id`      | int             | 回合唯一编号                                 |
+| `epoch`   | int             | 期次（Epoch）                                 |
 | `lockPrice`    | string(decimal) | 锁定价格                                 |
 | `currentPrice` | string(decimal) | 最新价格                                 |
 | `totalAmount`  | string(decimal) | 总下注金额                               |
@@ -70,7 +71,8 @@ await hub.start();
 
 ```json
 {
-  "roundId": 357690,
+  "id": 357690,
+  "epoch": 357690,
   "lockPrice": "308.85000000",
   "currentPrice": "309.12500000",
   "totalAmount": "2500.00000000",
@@ -94,7 +96,8 @@ await hub.start();
 
 | 字段名    | 类型 | 说明     |
 | --------- | ---- | -------- |
-| `roundId` | int  | 期次（Epoch） |
+| `id` | int  | 回合唯一编号 |
+| `epoch` | int | 期次（Epoch） |
 ## 3️⃣ 回合锁定通知（`roundLocked` • WS 广播）
 
 - **SignalR 事件**：`roundLocked`
@@ -103,7 +106,8 @@ await hub.start();
 
 | 字段名 | 类型 | 说明 |
 | --- | --- | --- |
-| `roundId` | int | 期次（Epoch） |
+| `id` | int | 回合唯一编号 |
+| `epoch` | int | 期次（Epoch） |
 
 
 ## 4️⃣ 开始结算通知（`settlementStarted` • WS 广播）
@@ -114,7 +118,8 @@ await hub.start();
 
 | 字段名    | 类型 | 说明     |
 | --------- | ---- | -------- |
-| `roundId` | int  | 期次（Epoch） |
+| `id` | int  | 回合唯一编号 |
+| `epoch` | int | 期次（Epoch） |
 
 ## 5️⃣ 结束结算通知（`settlementEnded` • WS 广播）
 
@@ -124,7 +129,8 @@ await hub.start();
 
 | 字段名    | 类型 | 说明     |
 | --------- | ---- | -------- |
-| `roundId` | int  | 期次（Epoch） |
+| `id` | int  | 回合唯一编号 |
+| `epoch` | int | 期次（Epoch） |
 
 ## 6️⃣ 回合结束通知（`roundEnded` • WS 广播）
 
@@ -134,12 +140,13 @@ await hub.start();
 
 | 字段名    | 类型 | 说明     |
 | --------- | ---- | -------- |
-| `roundId` | int  | 期次（Epoch） |
+| `id` | int  | 回合唯一编号 |
+| `epoch` | int | 期次（Epoch） |
 
 **示例：**
 
 ```json
-{ "roundId": 357690 }
+{ "id": 357690, "epoch": 357690 }
 ```
 
 ------
@@ -152,7 +159,8 @@ await hub.start();
 
 | 字段名        | 类型            | 说明               |
 | ------------- | --------------- | ------------------ |
-| `roundId`     | int             | 期次（Epoch）           |
+| `id`     | int             | 回合唯一编号           |
+| `epoch`  | int             | 期次（Epoch）           |
 | `lockPrice`   | string(decimal) | 锁定价格           |
 | `closePrice`  | string(decimal) | 收盘价格           |
 | `totalAmount` | string(decimal) | 总下注金额         |
@@ -168,7 +176,7 @@ await hub.start();
 ```json
 [
   {
-    "roundId": 357689,
+    "id": 357689,
     "lockPrice": "308.85000000",
     "closePrice": "309.75000000",
     "totalAmount": "1800.00000000",
@@ -192,7 +200,8 @@ await hub.start();
 
 | 字段名      | 类型 | 说明           |
 | ----------- | ---- | -------------- |
-| `roundId`   | int  | 期次（Epoch）       |
+| `id`   | int  | 回合唯一编号（可能为 0） |
+| `epoch` | int  | 期次（Epoch）       |
 | `startTime` | int  | 开始时间（秒） |
 | `endTime`   | int  | 结束时间（秒） |
 
@@ -230,7 +239,8 @@ GET /api/predictions/round
 
 | 字段名       | 类型            | 说明                    |
 | ------------ | --------------- | ----------------------- |
-| `roundId`    | int             | 期次（Epoch）                |
+| `id`    | int             | 回合唯一编号                |
+| `epoch` | int             | 期次（Epoch）                |
 | `position`   | enum            | `up` | `down`           |
 | `amount`     | string(decimal) | 押注金额                |
 | `lockPrice`  | string(decimal) | 锁定价格                |
@@ -266,7 +276,7 @@ GET /api/predictions/pnl
 
 请求体：
 ```json
-{ "roundId": 123, "address": "EQ..." }
+{ "id": 123, "address": "EQ..." }
 ```
 
 返回字段：

--- a/TonPrediction.Api/Services/PredictionHubService.cs
+++ b/TonPrediction.Api/Services/PredictionHubService.cs
@@ -10,7 +10,7 @@ namespace TonPrediction.Api.Services;
 /// <summary>
 /// SignalR 推送实现。
 /// </summary>
-public class PredictionHubService(ILogger<PredictionHubService> logger,IHubContext<PredictionHub> hub) : IPredictionHubService
+public class PredictionHubService(ILogger<PredictionHubService> logger, IHubContext<PredictionHub> hub) : IPredictionHubService
 {
     private readonly IHubContext<PredictionHub> _hub = hub;
 
@@ -26,7 +26,8 @@ public class PredictionHubService(ILogger<PredictionHubService> logger,IHubConte
         var oddsBear = round.BearAmount > 0m ? round.TotalAmount / round.BearAmount : 0m;
         var output = new CurrentRoundOutput
         {
-            RoundId = round.Epoch,
+            RoundId = round.Id,
+            Epoch = round.Epoch,
             LockPrice = round.LockPrice.ToString("F8"),
             CurrentPrice = currentPrice.ToString("F8"),
             TotalAmount = round.TotalAmount.ToString("F8"),
@@ -45,45 +46,50 @@ public class PredictionHubService(ILogger<PredictionHubService> logger,IHubConte
     /// <summary>
     /// 回合开始
     /// </summary>
-    /// <param name="roundId"></param>
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
     /// <returns></returns>
-    public Task PushRoundStartedAsync(long roundId)
+    public Task PushRoundStartedAsync(long roundId, long epoch)
     {
-        var output = new RoundStartedOutput { RoundId = roundId };
+        var output = new RoundStartedOutput { RoundId = roundId, Epoch = epoch };
         logger.LogDebug("PushCurrentRoundAsync.当前回合信息推送:{output}", JsonConvert.SerializeObject(output));
         return _hub.Clients.All.SendAsync("roundStarted", output);
     }
-   
+
 
     /// <summary>
     /// 锁定回合
     /// </summary>
-    /// <param name="roundId"></param>
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
     /// <returns></returns>
-    public Task PushRoundLockedAsync(long roundId) =>
-        _hub.Clients.All.SendAsync("roundLocked", new RoundLockedOutput { RoundId = roundId });
+    public Task PushRoundLockedAsync(long roundId, long epoch) =>
+        _hub.Clients.All.SendAsync("roundLocked", new RoundLockedOutput { RoundId = roundId, Epoch = epoch });
 
     /// <summary>
     /// 推送开始结算消息
     /// </summary>
-    /// <param name="roundId"></param>
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
     /// <returns></returns>
-    public Task PushSettlementStartedAsync(long roundId) =>
-        _hub.Clients.All.SendAsync("settlementStarted", new SettlementStartedOutput { RoundId = roundId });
+    public Task PushSettlementStartedAsync(long roundId, long epoch) =>
+        _hub.Clients.All.SendAsync("settlementStarted", new SettlementStartedOutput { RoundId = roundId, Epoch = epoch });
 
     /// <summary>
     /// 回合结束
     /// </summary>
-    /// <param name="roundId"></param>
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
     /// <returns></returns>
-    public Task PushRoundEndedAsync(long roundId) =>
-        _hub.Clients.All.SendAsync("roundEnded", new RoundEndedOutput { RoundId = roundId });
+    public Task PushRoundEndedAsync(long roundId, long epoch) =>
+        _hub.Clients.All.SendAsync("roundEnded", new RoundEndedOutput { RoundId = roundId, Epoch = epoch });
 
     /// <summary>
     /// 推送结算结束消息
     /// </summary>
-    /// <param name="roundId"></param>
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
     /// <returns></returns>
-    public Task PushSettlementEndedAsync(long roundId) =>
-        _hub.Clients.All.SendAsync("settlementEnded", new SettlementEndedOutput { RoundId = roundId });
+    public Task PushSettlementEndedAsync(long roundId, long epoch) =>
+        _hub.Clients.All.SendAsync("settlementEnded", new SettlementEndedOutput { RoundId = roundId, Epoch = epoch });
 }

--- a/TonPrediction.Api/Services/RoundScheduler.cs
+++ b/TonPrediction.Api/Services/RoundScheduler.cs
@@ -128,8 +128,8 @@ namespace TonPrediction.Api.Services
                 }
 
                 await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = closePrice });
-                await _notifier.PushRoundEndedAsync(locked.Epoch);
-                await _notifier.PushSettlementEndedAsync(locked.Epoch);
+                await _notifier.PushRoundEndedAsync(locked.Id, locked.Epoch);
+                await _notifier.PushSettlementEndedAsync(locked.Id, locked.Epoch);
             }
 
             // 获取当前可下注的回合
@@ -154,8 +154,8 @@ namespace TonPrediction.Api.Services
                     };
                     await roundRepo.InsertAsync(genesisLocked);
                     await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = startPrice });
-                    await _notifier.PushRoundLockedAsync(genesisLocked.Epoch);
-                    await _notifier.PushSettlementStartedAsync(genesisLocked.Epoch);
+                    await _notifier.PushRoundLockedAsync(genesisLocked.Id, genesisLocked.Epoch);
+                    await _notifier.PushSettlementStartedAsync(genesisLocked.Id, genesisLocked.Epoch);
 
                     var liveRound = new RoundEntity
                     {
@@ -170,7 +170,7 @@ namespace TonPrediction.Api.Services
                     await roundRepo.InsertAsync(liveRound);
                     await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = startPrice });
                     await _notifier.PushCurrentRoundAsync(liveRound, liveRound.LockPrice);
-                    await _notifier.PushRoundStartedAsync(liveRound.Epoch);
+                    await _notifier.PushRoundStartedAsync(liveRound.Id, liveRound.Epoch);
                 }
                 else
                 {
@@ -187,7 +187,7 @@ namespace TonPrediction.Api.Services
                     await roundRepo.InsertAsync(firstRound);
                     await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = startPrice });
                     await _notifier.PushCurrentRoundAsync(firstRound, firstRound.LockPrice);
-                    await _notifier.PushRoundStartedAsync(firstRound.Epoch);
+                    await _notifier.PushRoundStartedAsync(firstRound.Id, firstRound.Epoch);
                 }
 
                 return;
@@ -203,8 +203,8 @@ namespace TonPrediction.Api.Services
                 live.Status = RoundStatus.Locked;
                 await roundRepo.UpdateByPrimaryKeyAsync(live);
                 await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = lockPrice });
-                await _notifier.PushRoundLockedAsync(live.Epoch);
-                await _notifier.PushSettlementStartedAsync(live.Epoch);
+                await _notifier.PushRoundLockedAsync(live.Id, live.Epoch);
+                await _notifier.PushSettlementStartedAsync(live.Id, live.Epoch);
 
                 var nextPrice = lockPrice;
                 var nextRound = new RoundEntity
@@ -220,7 +220,7 @@ namespace TonPrediction.Api.Services
                 await roundRepo.InsertAsync(nextRound);
                 await priceRepo.InsertAsync(new PriceSnapshotEntity { Symbol = symbol, Timestamp = now, Price = nextPrice });
                 await _notifier.PushCurrentRoundAsync(nextRound, nextRound.LockPrice);
-                await _notifier.PushRoundStartedAsync(nextRound.Epoch);
+                await _notifier.PushRoundStartedAsync(nextRound.Id, nextRound.Epoch);
             }
         }
     }

--- a/TonPrediction.Application/Database/Repository/IRoundRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IRoundRepository.cs
@@ -37,7 +37,7 @@ namespace TonPrediction.Application.Database.Repository
         /// </summary>
         /// <param name="symbol"></param>
         /// <param name="limit">限制数量。</param>
-        Task<List<RoundEntity>> GetEndedAsync(string symbol,int limit);
+        Task<List<RoundEntity>> GetEndedAsync(string symbol, int limit);
 
         /// <summary>
         /// 根据编号批量查询回合。

--- a/TonPrediction.Application/Output/BetRecordOutput.cs
+++ b/TonPrediction.Application/Output/BetRecordOutput.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using TonPrediction.Application.Enums;
 
 namespace TonPrediction.Application.Output;
@@ -8,8 +9,9 @@ namespace TonPrediction.Application.Output;
 public class BetRecordOutput
 {
     /// <summary>
-    /// 回合编号。
+    /// 回合唯一编号，用于业务请求。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
 
     /// <summary>

--- a/TonPrediction.Application/Output/CurrentRoundOutput.cs
+++ b/TonPrediction.Application/Output/CurrentRoundOutput.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using TonPrediction.Application.Enums;
 
 namespace TonPrediction.Application.Output;
@@ -8,9 +9,15 @@ namespace TonPrediction.Application.Output;
 public class CurrentRoundOutput
 {
     /// <summary>
-    /// 回合编号。
+    /// 回合唯一编号，用于业务请求。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
+
+    /// <summary>
+    /// 期次，从 1 开始递增。
+    /// </summary>
+    public long Epoch { get; set; }
 
     /// <summary>
     /// 锁定价格。

--- a/TonPrediction.Application/Output/RoundEndedOutput.cs
+++ b/TonPrediction.Application/Output/RoundEndedOutput.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace TonPrediction.Application.Output;
 
 /// <summary>
@@ -6,7 +8,13 @@ namespace TonPrediction.Application.Output;
 public class RoundEndedOutput
 {
     /// <summary>
-    /// 已结束回合的编号。
+    /// 已结束回合的唯一编号，用于业务请求。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
+
+    /// <summary>
+    /// 已结束回合的期次。
+    /// </summary>
+    public long Epoch { get; set; }
 }

--- a/TonPrediction.Application/Output/RoundHistoryOutput.cs
+++ b/TonPrediction.Application/Output/RoundHistoryOutput.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using TonPrediction.Application.Enums;
 
 namespace TonPrediction.Application.Output;
@@ -8,9 +9,15 @@ namespace TonPrediction.Application.Output;
 public class RoundHistoryOutput
 {
     /// <summary>
-    /// 回合编号。
+    /// 回合唯一编号，用于业务请求。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
+
+    /// <summary>
+    /// 期次，从 1 开始递增。
+    /// </summary>
+    public long Epoch { get; set; }
 
     /// <summary>
     /// 锁定价格。

--- a/TonPrediction.Application/Output/RoundLockedOutput.cs
+++ b/TonPrediction.Application/Output/RoundLockedOutput.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace TonPrediction.Application.Output;
 
 /// <summary>
@@ -6,7 +8,13 @@ namespace TonPrediction.Application.Output;
 public class RoundLockedOutput
 {
     /// <summary>
-    /// 锁定的回合编号。
+    /// 锁定的回合唯一编号，用于业务请求。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
+
+    /// <summary>
+    /// 锁定的回合期次。
+    /// </summary>
+    public long Epoch { get; set; }
 }

--- a/TonPrediction.Application/Output/RoundStartedOutput.cs
+++ b/TonPrediction.Application/Output/RoundStartedOutput.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace TonPrediction.Application.Output;
 
 /// <summary>
@@ -6,7 +8,13 @@ namespace TonPrediction.Application.Output;
 public class RoundStartedOutput
 {
     /// <summary>
-    /// 新回合编号。
+    /// 新回合唯一编号，用于业务请求。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
+
+    /// <summary>
+    /// 新回合期次。
+    /// </summary>
+    public long Epoch { get; set; }
 }

--- a/TonPrediction.Application/Output/SettlementEndedOutput.cs
+++ b/TonPrediction.Application/Output/SettlementEndedOutput.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace TonPrediction.Application.Output;
 
 /// <summary>
@@ -6,7 +8,13 @@ namespace TonPrediction.Application.Output;
 public class SettlementEndedOutput
 {
     /// <summary>
-    /// 已结算回合编号。
+    /// 已结算回合的唯一编号，用于业务请求。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
+
+    /// <summary>
+    /// 已结算回合期次。
+    /// </summary>
+    public long Epoch { get; set; }
 }

--- a/TonPrediction.Application/Output/SettlementStartedOutput.cs
+++ b/TonPrediction.Application/Output/SettlementStartedOutput.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace TonPrediction.Application.Output;
 
 /// <summary>
@@ -6,7 +8,13 @@ namespace TonPrediction.Application.Output;
 public class SettlementStartedOutput
 {
     /// <summary>
-    /// 进入结算阶段的回合编号。
+    /// 进入结算阶段的回合唯一编号，用于业务请求。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
+
+    /// <summary>
+    /// 进入结算阶段的回合期次。
+    /// </summary>
+    public long Epoch { get; set; }
 }

--- a/TonPrediction.Application/Output/UpcomingRoundOutput.cs
+++ b/TonPrediction.Application/Output/UpcomingRoundOutput.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace TonPrediction.Application.Output;
 
 /// <summary>
@@ -6,9 +8,15 @@ namespace TonPrediction.Application.Output;
 public class UpcomingRoundOutput
 {
     /// <summary>
-    /// 回合编号（预计）。
+    /// 回合唯一编号（预计），部分回合可能为 0。
     /// </summary>
+    [JsonPropertyName("id")]
     public long RoundId { get; set; }
+
+    /// <summary>
+    /// 回合期次（预计）。
+    /// </summary>
+    public long Epoch { get; set; }
 
     /// <summary>
     /// 开始时间 Unix 秒。

--- a/TonPrediction.Application/Services/Interface/IPredictionHubService.cs
+++ b/TonPrediction.Application/Services/Interface/IPredictionHubService.cs
@@ -20,30 +20,35 @@ public interface IPredictionHubService : ITransientDependency
     /// <summary>
     /// 推送回合开始消息。
     /// </summary>
-    /// <param name="roundId">回合编号。</param>
-    Task PushRoundStartedAsync(long roundId);
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
+    Task PushRoundStartedAsync(long roundId, long epoch);
 
     /// <summary>
     /// 推送回合锁定消息。
     /// </summary>
-    /// <param name="roundId">回合编号。</param>
-    Task PushRoundLockedAsync(long roundId);
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
+    Task PushRoundLockedAsync(long roundId, long epoch);
 
     /// <summary>
     /// 推送结算开始消息。
     /// </summary>
-    /// <param name="roundId">回合编号。</param>
-    Task PushSettlementStartedAsync(long roundId);
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
+    Task PushSettlementStartedAsync(long roundId, long epoch);
 
     /// <summary>
     /// 推送回合结束消息。
     /// </summary>
-    /// <param name="roundId">回合编号。</param>
-    Task PushRoundEndedAsync(long roundId);
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
+    Task PushRoundEndedAsync(long roundId, long epoch);
 
     /// <summary>
     /// 推送结算结束消息。
     /// </summary>
-    /// <param name="roundId">回合编号。</param>
-    Task PushSettlementEndedAsync(long roundId);
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
+    Task PushSettlementEndedAsync(long roundId, long epoch);
 }

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -28,7 +28,8 @@ public class RoundService(
         var list = await _roundRepo.GetEndedAsync(symbol, limit);
         return list.Select(r => new RoundHistoryOutput
         {
-            RoundId = r.Epoch,
+            RoundId = r.Id,
+            Epoch = r.Epoch,
             LockPrice = r.LockPrice.ToString("F8"),
             ClosePrice = r.ClosePrice.ToString("F8"),
             TotalAmount = r.TotalAmount.ToString("F8"),
@@ -61,7 +62,8 @@ public class RoundService(
             var s = startTime.AddSeconds(intervalSec * i);
             list.Add(new UpcomingRoundOutput
             {
-                RoundId = startEpoch + i,
+                RoundId = 0,
+                Epoch = startEpoch + i,
                 StartTime = new DateTimeOffset(s).ToUnixTimeSeconds(),
                 EndTime = new DateTimeOffset(s.AddSeconds(intervalSec)).ToUnixTimeSeconds()
             });

--- a/TonPrediction.Infrastructure/Services/RedisDistributedLock.cs
+++ b/TonPrediction.Infrastructure/Services/RedisDistributedLock.cs
@@ -30,7 +30,7 @@ public class RedisDistributedLock(IEnumerable<IRedisDatabaseProvider> redisDatab
     /// <param name="expiry"></param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    public async Task<IDisposable?> AcquireAsync(string key,TimeSpan expiry)
+    public async Task<IDisposable?> AcquireAsync(string key, TimeSpan expiry)
     {
         var db = GetDatabase();
         var token = Guid.NewGuid().ToString();

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -39,11 +39,11 @@ public class TonEventListenerTests
             .Callback<BetEntity>(b => inserted = b)
             .ReturnsAsync(new BetEntity())
             .Verifiable();
-        betRepo.Setup(b => b.GetByTxHashAsync("hash", It.IsAny<CancellationToken>()))
+        betRepo.Setup(b => b.GetByTxHashAsync("hash"))
             .ReturnsAsync((BetEntity?)null);
 
         var roundRepo = new Mock<IRoundRepository>();
-        roundRepo.Setup(r => r.GetCurrentLiveAsync("ton", It.IsAny<CancellationToken>()))
+        roundRepo.Setup(r => r.GetCurrentLiveAsync("ton"))
             .ReturnsAsync(round);
         roundRepo.Setup(r => r.UpdateByPrimaryKeyAsync(round))
             .ReturnsAsync(true)
@@ -52,8 +52,7 @@ public class TonEventListenerTests
         var notifier = new Mock<IPredictionHubService>();
         notifier.Setup(n => n.PushCurrentRoundAsync(
                 round,
-                It.IsAny<decimal>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<decimal>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
 
@@ -87,14 +86,13 @@ public class TonEventListenerTests
         {
             Lt = 1
         };
-        await listener.ProcessTransactionAsync(tx, CancellationToken.None);
+        await listener.ProcessTransactionAsync(tx);
 
         betRepo.Verify(b => b.InsertAsync(It.IsAny<BetEntity>()), Times.Once);
         roundRepo.Verify(r => r.UpdateByPrimaryKeyAsync(round), Times.Once);
         notifier.Verify(n => n.PushCurrentRoundAsync(
             round,
-            It.IsAny<decimal>(),
-            It.IsAny<CancellationToken>()), Times.Once);
+            It.IsAny<decimal>()), Times.Once);
 
         Assert.Equal("hash", inserted?.TxHash);
         Assert.Equal<ulong>(1ul, inserted?.Lt ?? 0);
@@ -115,12 +113,12 @@ public class TonEventListenerTests
 
         var bet = new BetEntity { TxHash = "hash", Lt = 0, Status = BetStatus.Pending };
         var betRepo = new Mock<IBetRepository>();
-        betRepo.Setup(b => b.GetByTxHashAsync("hash", It.IsAny<CancellationToken>()))
+        betRepo.Setup(b => b.GetByTxHashAsync("hash"))
             .ReturnsAsync(bet);
         betRepo.Setup(b => b.UpdateByPrimaryKeyAsync(bet)).ReturnsAsync(true).Verifiable();
 
         var roundRepo = new Mock<IRoundRepository>();
-        roundRepo.Setup(r => r.GetCurrentLiveAsync("ton", It.IsAny<CancellationToken>()))
+        roundRepo.Setup(r => r.GetCurrentLiveAsync("ton"))
             .ReturnsAsync(round);
 
         var notifier = new Mock<IPredictionHubService>();
@@ -150,7 +148,7 @@ public class TonEventListenerTests
             Mock.Of<IDistributedLock>());
 
         var tx = new TonTxDetail(1m, new InMsg("sender", "ton bull", "addr"), "hash") { Lt = 2 };
-        await listener.ProcessTransactionAsync(tx, CancellationToken.None);
+        await listener.ProcessTransactionAsync(tx);
 
         betRepo.Verify(b => b.UpdateByPrimaryKeyAsync(bet), Times.Once);
     }


### PR DESCRIPTION
## Summary
- include `id` and `epoch` in round outputs
- adjust hub service and scheduler to push both values
- update API spec for new fields
- fix unit tests and formatting

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686c9d78e8d8832393fdc3421da650e8