### PR TITLE
refactor: move ApiResult to application services

### DIFF
--- a/TonPrediction.Api/Controllers/BetController.cs
+++ b/TonPrediction.Api/Controllers/BetController.cs
@@ -20,9 +20,6 @@ public class BetController(IBetService betService) : ControllerBase
     [HttpPost("report")]
     public async Task<ApiResult<bool>> ReportAsync([FromBody] TxHashInput input)
     {
-        var ok = await _betService.ReportAsync(input.TxHash);
-        var api = new ApiResult<bool>();
-        api.SetRsult(ok ? ApiResultCode.Success : ApiResultCode.ErrorParams, ok);
-        return api;
+        return await _betService.ReportAsync(input.TxHash);
     }
 }

--- a/TonPrediction.Api/Controllers/ClaimController.cs
+++ b/TonPrediction.Api/Controllers/ClaimController.cs
@@ -21,9 +21,6 @@ public class ClaimController(IClaimService claimService) : ControllerBase
     [HttpPost]
     public async Task<ApiResult<ClaimOutput?>> ClaimAsync([FromBody] ClaimInput input)
     {
-        var output = await _claimService.ClaimAsync(input);
-        var api = new ApiResult<ClaimOutput?>();
-        api.SetRsult(output != null ? ApiResultCode.Success : ApiResultCode.ErrorParams, output);
-        return api;
+        return await _claimService.ClaimAsync(input);
     }
 }

--- a/TonPrediction.Api/Controllers/PredictionsController.cs
+++ b/TonPrediction.Api/Controllers/PredictionsController.cs
@@ -24,10 +24,7 @@ public class PredictionsController(IPredictionService predictionService) : Contr
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10)
     {
-        var list = await _predictionService.GetRecordsAsync(address, status, page, pageSize);
-        var api = new ApiResult<List<BetRecordOutput>>();
-        api.SetRsult(ApiResultCode.Success, list);
-        return api;
+        return await _predictionService.GetRecordsAsync(address, status, page, pageSize);
     }
 
     /// <summary>
@@ -36,9 +33,6 @@ public class PredictionsController(IPredictionService predictionService) : Contr
     [HttpGet("pnl")]
     public async Task<ApiResult<PnlOutput>> GetPnlAsync([FromQuery] string address)
     {
-        var output = await _predictionService.GetPnlAsync(address);
-        var api = new ApiResult<PnlOutput>();
-        api.SetRsult(ApiResultCode.Success, output);
-        return api;
+        return await _predictionService.GetPnlAsync(address);
     }
 }

--- a/TonPrediction.Api/Controllers/RoundController.cs
+++ b/TonPrediction.Api/Controllers/RoundController.cs
@@ -22,10 +22,7 @@ public class RoundController(IRoundService roundService) : ControllerBase
         [FromQuery] string symbol = "ton",
         [FromQuery] int limit = 3)
     {
-        var result = await _roundService.GetHistoryAsync(symbol, limit);
-        var api = new ApiResult<List<RoundHistoryOutput>>();
-        api.SetRsult(ApiResultCode.Success, result);
-        return api;
+        return await _roundService.GetHistoryAsync(symbol, limit);
     }
 
     /// <summary>
@@ -35,9 +32,6 @@ public class RoundController(IRoundService roundService) : ControllerBase
     public async Task<ApiResult<List<UpcomingRoundOutput>>> GetUpcomingAsync(
         [FromQuery] string symbol = "ton")
     {
-        var list = await _roundService.GetUpcomingAsync(symbol);
-        var api = new ApiResult<List<UpcomingRoundOutput>>();
-        api.SetRsult(ApiResultCode.Success, list);
-        return api;
+        return await _roundService.GetUpcomingAsync(symbol);
     }
 }

--- a/TonPrediction.Application/Services/Interface/IBetService.cs
+++ b/TonPrediction.Application/Services/Interface/IBetService.cs
@@ -1,4 +1,5 @@
 using QYQ.Base.Common.IOCExtensions;
+using QYQ.Base.Common.ApiResult;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +14,6 @@ public interface IBetService : ITransientDependency
     /// 根据交易哈希上报下注。
     /// </summary>
     /// <param name="txHash">交易哈希。</param>
-    /// <returns>是否受理成功。</returns>
-    Task<bool> ReportAsync(string txHash);
+    /// <returns>业务结果。</returns>
+    Task<ApiResult<bool>> ReportAsync(string txHash);
 }

--- a/TonPrediction.Application/Services/Interface/IClaimService.cs
+++ b/TonPrediction.Application/Services/Interface/IClaimService.cs
@@ -1,4 +1,5 @@
 using QYQ.Base.Common.IOCExtensions;
+using QYQ.Base.Common.ApiResult;
 using TonPrediction.Application.Input;
 using TonPrediction.Application.Output;
 
@@ -13,6 +14,6 @@ public interface IClaimService : ITransientDependency
     /// 执行领奖操作。
     /// </summary>
     /// <param name="input">领奖参数。</param>
-    /// <returns>领奖结果，失败返回 null。</returns>
-    Task<ClaimOutput?> ClaimAsync(ClaimInput input);
+    /// <returns>业务结果。</returns>
+    Task<ApiResult<ClaimOutput?>> ClaimAsync(ClaimInput input);
 }

--- a/TonPrediction.Application/Services/Interface/IPredictionService.cs
+++ b/TonPrediction.Application/Services/Interface/IPredictionService.cs
@@ -1,4 +1,5 @@
 using QYQ.Base.Common.IOCExtensions;
+using QYQ.Base.Common.ApiResult;
 using TonPrediction.Application.Output;
 
 namespace TonPrediction.Application.Services.Interface;
@@ -17,7 +18,7 @@ public interface IPredictionService : ITransientDependency
     /// <param name="pageSize">每页条数。</param>
     /// <param name="ct">取消任务标记。</param>
     /// <returns>下注记录列表。</returns>
-    Task<List<BetRecordOutput>> GetRecordsAsync(
+    Task<ApiResult<List<BetRecordOutput>>> GetRecordsAsync(
         string address,
         string status = "all",
         int page = 1,
@@ -29,5 +30,5 @@ public interface IPredictionService : ITransientDependency
     /// </summary>
     /// <param name="address">用户地址。</param>
     /// <returns>盈亏信息。</returns>
-    Task<PnlOutput> GetPnlAsync(string address);
+    Task<ApiResult<PnlOutput>> GetPnlAsync(string address);
 }

--- a/TonPrediction.Application/Services/Interface/IRoundService.cs
+++ b/TonPrediction.Application/Services/Interface/IRoundService.cs
@@ -1,4 +1,5 @@
 using QYQ.Base.Common.IOCExtensions;
+using QYQ.Base.Common.ApiResult;
 using TonPrediction.Application.Output;
 
 namespace TonPrediction.Application.Services.Interface;
@@ -15,7 +16,7 @@ public interface IRoundService : ITransientDependency
     /// <param name="symbol"></param>
     /// <param name="ct">取消任务标记。</param>
     /// <returns>历史回合集合。</returns>
-    Task<List<RoundHistoryOutput>> GetHistoryAsync(
+    Task<ApiResult<List<RoundHistoryOutput>>> GetHistoryAsync(
         string symbol = "ton",
         int limit = 3,
         CancellationToken ct = default);
@@ -26,7 +27,7 @@ public interface IRoundService : ITransientDependency
     /// <param name="symbol"></param>
     /// <param name="ct">取消任务标记。</param>
     /// <returns>回合时间集合。</returns>
-    Task<List<UpcomingRoundOutput>> GetUpcomingAsync(
+    Task<ApiResult<List<UpcomingRoundOutput>>> GetUpcomingAsync(
         string symbol = "ton",
         CancellationToken ct = default);
 }

--- a/TonPrediction.Application/Services/PredictionService.cs
+++ b/TonPrediction.Application/Services/PredictionService.cs
@@ -4,6 +4,7 @@ using TonPrediction.Application.Database.Repository;
 using TonPrediction.Application.Enums;
 using TonPrediction.Application.Output;
 using TonPrediction.Application.Services.Interface;
+using QYQ.Base.Common.ApiResult;
 
 namespace TonPrediction.Application.Services;
 
@@ -26,13 +27,14 @@ public class PredictionService(
     /// <param name="pageSize"></param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    public async Task<List<BetRecordOutput>> GetRecordsAsync(
+    public async Task<ApiResult<List<BetRecordOutput>>> GetRecordsAsync(
         string address,
         string status = "all",
         int page = 1,
         int pageSize = 10,
         CancellationToken ct = default)
     {
+        var api = new ApiResult<List<BetRecordOutput>>();
         page = page <= 0 ? 1 : page;
         pageSize = pageSize is <= 0 or > 100 ? 10 : pageSize;
         var bets = await _betRepo.GetPagedByAddressAsync(address, status, page, pageSize);
@@ -64,18 +66,20 @@ public class PredictionService(
             };
             list.Add(output);
         }
-        return list;
+        api.SetRsult(ApiResultCode.Success, list);
+        return api;
     }
 
     /// <inheritdoc />
-    public async Task<PnlOutput> GetPnlAsync(string address)
+    public async Task<ApiResult<PnlOutput>> GetPnlAsync(string address)
     {
+        var api = new ApiResult<PnlOutput>();
         var bets = await _betRepo.GetByAddressAsync(address);
         var totalBet = bets.Sum(b => b.Amount);
         var totalReward = bets.Sum(b => b.Reward);
         var rounds = bets.Count;
         var winRounds = bets.Count(b => b.Reward > 0m);
-        return new PnlOutput
+        var output = new PnlOutput
         {
             TotalBet = totalBet.ToString("F8"),
             TotalReward = totalReward.ToString("F8"),
@@ -83,5 +87,7 @@ public class PredictionService(
             Rounds = rounds,
             WinRounds = winRounds
         };
+        api.SetRsult(ApiResultCode.Success, output);
+        return api;
     }
 }


### PR DESCRIPTION
## Summary
- return `ApiResult<T>` directly from application services
- simplify API controllers by delegating business codes to services

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686cbd4982848323b0c7698afb92f0a5