### PR TITLE
feat(api): refine amount formatting

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -74,12 +74,12 @@
 {
   "id": 357690,
   "epoch": 357690,
-  "lockPrice": "308.85000000",
-  "currentPrice": "309.12500000",
-  "totalAmount": "2500.00000000",
-  "bullAmount": "1400.00000000",
-  "bearAmount": "1100.00000000",
-  "rewardPool": "2425.00000000",
+  "lockPrice": "308.85",
+  "currentPrice": "309.125",
+  "totalAmount": "2500",
+  "bullAmount": "1400",
+  "bearAmount": "1100",
+  "rewardPool": "2425",
   "endTime": 1710001234,
   "status": "live",
   "bullOdds": "1.78571428",
@@ -178,15 +178,15 @@
 [
   {
     "id": 357689,
-    "lockPrice": "308.85000000",
-    "closePrice": "309.75000000",
-    "totalAmount": "1800.00000000",
-    "bullAmount": "1000.00000000",
-    "bearAmount": "800.00000000",
-    "rewardPool": "1746.00000000",
+    "lockPrice": "308.85",
+    "closePrice": "309.75",
+    "totalAmount": "1800",
+    "bullAmount": "1000",
+    "bearAmount": "800",
+    "rewardPool": "1746",
     "endTime": 1709999999,
-    "bullOdds": "1.80000000",
-    "bearOdds": "2.25000000"
+    "bullOdds": "1.8",
+    "bearOdds": "2.25"
   }
 ]
 ```

--- a/TonPrediction.Api/Controllers/PriceController.cs
+++ b/TonPrediction.Api/Controllers/PriceController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using QYQ.Base.Common.ApiResult;
 using TonPrediction.Application.Database.Repository;
 using TonPrediction.Application.Output;
+using TonPrediction.Application.Extensions;
 
 namespace TonPrediction.Api.Controllers;
 
@@ -25,7 +26,7 @@ public class PriceController(IPriceSnapshotRepository repo) : ControllerBase
         var output = new ChartDataOutput
         {
             Timestamps = list.Select(d => new DateTimeOffset(d.Timestamp).ToUnixTimeSeconds()).ToArray(),
-            Prices = list.Select(d => d.Price.ToString("F8")).ToArray()
+            Prices = list.Select(d => d.Price.ToAmountString()).ToArray()
         };
         var api = new ApiResult<ChartDataOutput>();
         api.SetRsult(ApiResultCode.Success, output);

--- a/TonPrediction.Api/Services/PredictionHubService.cs
+++ b/TonPrediction.Api/Services/PredictionHubService.cs
@@ -4,6 +4,7 @@ using TonPrediction.Api.Hubs;
 using TonPrediction.Application.Database.Entities;
 using TonPrediction.Application.Output;
 using TonPrediction.Application.Services.Interface;
+using TonPrediction.Application.Extensions;
 
 namespace TonPrediction.Api.Services;
 
@@ -28,15 +29,15 @@ public class PredictionHubService(ILogger<PredictionHubService> logger, IHubCont
         {
             RoundId = round.Id,
             Epoch = round.Epoch,
-            LockPrice = round.LockPrice.ToString("F8"),
-            CurrentPrice = currentPrice.ToString("F8"),
-            TotalAmount = round.TotalAmount.ToString("F8"),
-            BullAmount = round.BullAmount.ToString("F8"),
-            BearAmount = round.BearAmount.ToString("F8"),
-            RewardPool = round.RewardAmount.ToString("F8"),
+            LockPrice = round.LockPrice.ToAmountString(),
+            CurrentPrice = currentPrice.ToAmountString(),
+            TotalAmount = round.TotalAmount.ToAmountString(),
+            BullAmount = round.BullAmount.ToAmountString(),
+            BearAmount = round.BearAmount.ToAmountString(),
+            RewardPool = round.RewardAmount.ToAmountString(),
             EndTime = new DateTimeOffset(round.CloseTime).ToUnixTimeSeconds(),
-            BullOdds = oddsBull.ToString("F8"),
-            BearOdds = oddsBear.ToString("F8"),
+            BullOdds = oddsBull.ToAmountString(),
+            BearOdds = oddsBear.ToAmountString(),
             Status = round.Status
         };
         logger.LogDebug("PushCurrentRoundAsync.当前回合信息推送:{output}", JsonConvert.SerializeObject(output));

--- a/TonPrediction.Application/Extensions/DecimalExtensions.cs
+++ b/TonPrediction.Application/Extensions/DecimalExtensions.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+
+namespace TonPrediction.Application.Extensions;
+
+/// <summary>
+/// decimal 扩展方法。
+/// </summary>
+public static class DecimalExtensions
+{
+    /// <summary>
+    /// 将金额转换为字符串，最多保留 8 位小数并去除尾部 0。
+    /// </summary>
+    /// <param name="value">十进制数值。</param>
+    /// <returns>格式化后的金额字符串。</returns>
+    public static string ToAmountString(this decimal value)
+        => decimal.Round(value, 8).ToString("0.########", CultureInfo.InvariantCulture);
+}

--- a/TonPrediction.Application/Services/PredictionService.cs
+++ b/TonPrediction.Application/Services/PredictionService.cs
@@ -4,6 +4,7 @@ using TonPrediction.Application.Database.Repository;
 using TonPrediction.Application.Enums;
 using TonPrediction.Application.Output;
 using TonPrediction.Application.Services.Interface;
+using TonPrediction.Application.Extensions;
 using QYQ.Base.Common.ApiResult;
 
 namespace TonPrediction.Application.Services;
@@ -56,10 +57,10 @@ public class PredictionService(
                 RoundId = bet.RoundId,
                 Epoch = round.Epoch,
                 Position = bet.Position,
-                Amount = bet.Amount.ToString("F8"),
-                LockPrice = round.LockPrice.ToString("F8"),
-                ClosePrice = round.ClosePrice.ToString("F8"),
-                Reward = bet.Reward.ToString("F8"),
+                Amount = bet.Amount.ToAmountString(),
+                LockPrice = round.LockPrice.ToAmountString(),
+                ClosePrice = round.ClosePrice.ToAmountString(),
+                Reward = bet.Reward.ToAmountString(),
                 Claimed = bet.Claimed,
                 TxHash = bet.TxHash,
                 Result = result
@@ -81,9 +82,9 @@ public class PredictionService(
         var winRounds = bets.Count(b => b.Reward > 0m);
         var output = new PnlOutput
         {
-            TotalBet = totalBet.ToString("F8"),
-            TotalReward = totalReward.ToString("F8"),
-            NetProfit = (totalReward - totalBet).ToString("F8"),
+            TotalBet = totalBet.ToAmountString(),
+            TotalReward = totalReward.ToAmountString(),
+            NetProfit = (totalReward - totalBet).ToAmountString(),
             Rounds = rounds,
             WinRounds = winRounds
         };

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -5,6 +5,7 @@ using TonPrediction.Application.Database.Repository;
 using TonPrediction.Application.Enums;
 using TonPrediction.Application.Output;
 using TonPrediction.Application.Services.Interface;
+using TonPrediction.Application.Extensions;
 using QYQ.Base.Common.ApiResult;
 
 namespace TonPrediction.Application.Services;
@@ -32,15 +33,15 @@ public class RoundService(
         {
             RoundId = r.Id,
             Epoch = r.Epoch,
-            LockPrice = r.LockPrice.ToString("F8"),
-            ClosePrice = r.ClosePrice.ToString("F8"),
-            TotalAmount = r.TotalAmount.ToString("F8"),
-            BullAmount = r.BullAmount.ToString("F8"),
-            BearAmount = r.BearAmount.ToString("F8"),
-            RewardPool = r.RewardAmount.ToString("F8"),
+            LockPrice = r.LockPrice.ToAmountString(),
+            ClosePrice = r.ClosePrice.ToAmountString(),
+            TotalAmount = r.TotalAmount.ToAmountString(),
+            BullAmount = r.BullAmount.ToAmountString(),
+            BearAmount = r.BearAmount.ToAmountString(),
+            RewardPool = r.RewardAmount.ToAmountString(),
             EndTime = new DateTimeOffset(r.CloseTime).ToUnixTimeSeconds(),
-            BullOdds = r.BullAmount > 0m ? (r.TotalAmount / r.BullAmount).ToString("F8") : "0",
-            BearOdds = r.BearAmount > 0m ? (r.TotalAmount / r.BearAmount).ToString("F8") : "0"
+            BullOdds = r.BullAmount > 0m ? (r.TotalAmount / r.BullAmount).ToAmountString() : "0",
+            BearOdds = r.BearAmount > 0m ? (r.TotalAmount / r.BearAmount).ToAmountString() : "0"
         }).ToList();
         api.SetRsult(ApiResultCode.Success, result);
         return api;


### PR DESCRIPTION
## Summary
- add `DecimalExtensions.ToAmountString` for trimming trailing zeroes
- format numbers using `ToAmountString`
- update API doc examples

## Testing
- `dotnet format --verify-no-changes -v diag`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686cdd9893e48323af4342e19bb57c34