### PR TITLE
feat: refine round statuses

### DIFF
--- a/TonPrediction.Application/Database/Entities/RoundEntity.cs
+++ b/TonPrediction.Application/Database/Entities/RoundEntity.cs
@@ -96,10 +96,10 @@ namespace TonPrediction.Application.Database.Entities
         public decimal BearAmount { get; set; }
 
         /// <summary>
-        /// 
+        /// 获胜方。
         /// </summary>
-        [SugarColumn(ColumnName = "winner_side", ColumnDataType = "decimal(18,8)")]
-        public decimal WinnerSide { get; set; }
+        [SugarColumn(ColumnName = "winner_side")]
+        public Position? WinnerSide { get; set; }
 
         /// <summary>
         /// 

--- a/TonPrediction.Application/Enums/RoundStatus.cs
+++ b/TonPrediction.Application/Enums/RoundStatus.cs
@@ -9,17 +9,25 @@ namespace TonPrediction.Application.Enums
         /// 即将开始。
         /// </summary>
         Upcoming = 0,
+
         /// <summary>
-        /// 正在进行。
+        /// 下注进行中。
         /// </summary>
-        Live = 1,
+        Betting = 1,
+
         /// <summary>
-        /// 已锁定，不可下注。
+        /// 已锁价，等待收盘。
         /// </summary>
-        Locked = 2,
+        Live = 2,
+
         /// <summary>
-        /// 已结束。
+        /// 结算中。
         /// </summary>
-        Ended = 3
+        Calculating = 3,
+
+        /// <summary>
+        /// 已完成，可领取奖励。
+        /// </summary>
+        Completed = 4
     }
 }

--- a/TonPrediction.Infrastructure/Database/Repository/RoundRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/RoundRepository.cs
@@ -35,7 +35,7 @@ namespace TonPrediction.Infrastructure.Database.Repository
         public async Task<RoundEntity?> GetCurrentLiveAsync(string symbol)
         {
             return await Db.Queryable<RoundEntity>()
-                .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Live)
+                .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Betting)
                 .OrderBy(r => r.Epoch, OrderByType.Desc)
                 .FirstAsync();
         }
@@ -53,7 +53,7 @@ namespace TonPrediction.Infrastructure.Database.Repository
         public async Task<RoundEntity?> GetCurrentLockedAsync(string symbol)
         {
             return await Db.Queryable<RoundEntity>()
-                .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Locked)
+                .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Live)
                 .OrderBy(r => r.Epoch, OrderByType.Desc)
                 .FirstAsync();
         }
@@ -62,7 +62,7 @@ namespace TonPrediction.Infrastructure.Database.Repository
         public async Task<List<RoundEntity>> GetEndedAsync(string symbol, int limit)
         {
             return await Db.Queryable<RoundEntity>()
-                .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Ended)
+                .Where(r => r.Symbol == symbol && r.Status == RoundStatus.Completed)
                 .OrderBy(r => r.Epoch, OrderByType.Desc)
                 .Take(limit)
                 .ToListAsync();

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -30,7 +30,7 @@ public class TonEventListenerTests
             Epoch = 1,
             CloseTime = DateTime.UtcNow.AddMinutes(5),
             LockPrice = 1m,
-            Status = RoundStatus.Live
+            Status = RoundStatus.Betting
         };
 
         BetEntity? inserted = null;
@@ -108,7 +108,7 @@ public class TonEventListenerTests
             Epoch = 1,
             CloseTime = DateTime.UtcNow.AddMinutes(5),
             LockPrice = 1m,
-            Status = RoundStatus.Live
+            Status = RoundStatus.Betting
         };
 
         var bet = new BetEntity { TxHash = "hash", Lt = 0, Status = BetStatus.Pending };


### PR DESCRIPTION
## Summary
- introduce `Betting`, `Live`, `Calculating`, `Completed` states
- update repositories and scheduler to use new round statuses
- adjust tests to match new state names

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686cf32afee88323a1044327185563c7