### PR TITLE
feat/bet: add round verify api

### DIFF
--- a/TonPrediction.Api/Controllers/BetController.cs
+++ b/TonPrediction.Api/Controllers/BetController.cs
@@ -15,6 +15,15 @@ public class BetController(IBetService betService) : ControllerBase
     private readonly IBetService _betService = betService;
 
     /// <summary>
+    /// 验证指定回合是否可以下注。
+    /// </summary>
+    [HttpGet("verify")]
+    public async Task<ApiResult<bool>> VerifyAsync([FromQuery] long roundId)
+    {
+        return await _betService.VerifyAsync(roundId);
+    }
+
+    /// <summary>
     /// 用户提交交易哈希以记录下注。
     /// </summary>
     [HttpPost("report")]

--- a/TonPrediction.Application/Services/BetService.cs
+++ b/TonPrediction.Application/Services/BetService.cs
@@ -78,6 +78,27 @@ public class BetService(
         api.SetRsult(ApiResultCode.Success, true);
         return api;
     }
+
+    /// <summary>
+    /// 验证指定回合是否可下注。
+    /// </summary>
+    /// <param name="roundId">回合编号。</param>
+    /// <returns>验证结果。</returns>
+    public async Task<ApiResult<bool>> VerifyAsync(long roundId)
+    {
+        var api = new ApiResult<bool>();
+        var round = await _roundRepo.GetByIdAsync(roundId);
+        if (round == null)
+        {
+            api.SetRsult(ApiResultCode.DataNotFound, false);
+            return api;
+        }
+
+        var now = DateTime.UtcNow;
+        var ok = round.Status == RoundStatus.Betting && round.LockTime > now;
+        api.SetRsult(ok ? ApiResultCode.Success : ApiResultCode.Fail, ok);
+        return api;
+    }
 }
 
 /// <summary>

--- a/TonPrediction.Application/Services/Interface/IBetService.cs
+++ b/TonPrediction.Application/Services/Interface/IBetService.cs
@@ -16,4 +16,11 @@ public interface IBetService : ITransientDependency
     /// <param name="txHash">交易哈希。</param>
     /// <returns>业务结果。</returns>
     Task<ApiResult<bool>> ReportAsync(string txHash);
+
+    /// <summary>
+    /// 验证指定回合是否可下注。
+    /// </summary>
+    /// <param name="roundId">回合编号。</param>
+    /// <returns>验证结果。</returns>
+    Task<ApiResult<bool>> VerifyAsync(long roundId);
 }

--- a/TonPrediction.Test/BetServiceTests.cs
+++ b/TonPrediction.Test/BetServiceTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TonPrediction.Application.Database.Entities;
+using TonPrediction.Application.Database.Repository;
+using TonPrediction.Application.Enums;
+using TonPrediction.Application.Services;
+using TonPrediction.Application.Services.Interface;
+using Xunit;
+
+namespace TonPrediction.Test;
+
+/// <summary>
+/// BetService 验证接口测试。
+/// </summary>
+public class BetServiceTests
+{
+    [Fact]
+    public async Task VerifyAsync_ReturnsSuccess_ForBettingRound()
+    {
+        var round = new RoundEntity
+        {
+            Id = 1,
+            LockTime = DateTime.UtcNow.AddMinutes(1),
+            Status = RoundStatus.Betting
+        };
+        var roundRepo = new Mock<IRoundRepository>();
+        roundRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(round);
+        var service = new BetService(
+            new Mock<IHttpClientFactory>().Object,
+            new ConfigurationBuilder().Build(),
+            Mock.Of<IBetRepository>(),
+            roundRepo.Object,
+            Mock.Of<IPredictionHubService>());
+
+        var result = await service.VerifyAsync(1);
+
+        Assert.True(result.Data);
+    }
+}


### PR DESCRIPTION
## Summary
- add VerifyAsync to IBetService and BetService to check if a round is bettable
- expose GET `/api/bet/verify` endpoint
- add BetServiceTests covering verify logic

## Related Issue
- Task: implement pre-bet validation API

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_686e0ab09aa0832385297d29503cd295