### PR TITLE
feat(api): enhance signalr push data

### DIFF
--- a/TonPrediction.Api/Services/PredictionHubService.cs
+++ b/TonPrediction.Api/Services/PredictionHubService.cs
@@ -53,11 +53,16 @@ public class PredictionHubService(ILogger<PredictionHubService> logger, IHubCont
     /// <returns></returns>
     public Task PushNextRoundAsync(RoundEntity round, decimal currentPrice)
     {
+        var oddsBull = round.BullAmount > 0m ? round.TotalAmount / round.BullAmount : 0m;
+        var oddsBear = round.BearAmount > 0m ? round.TotalAmount / round.BearAmount : 0m;
         var output = new NextRoundOutput
         {
             RoundId = round.Id,
             RewardPool = round.RewardAmount.ToAmountString(),
-            Symbol = round.Symbol
+            Symbol = round.Symbol,
+            CurrentPrice = currentPrice.ToAmountString(),
+            BullOdds = oddsBull.ToAmountString(),
+            BearOdds = oddsBear.ToAmountString()
         };
         logger.LogDebug("PushNextRoundAsync.下个回合奖池推送:{output}", JsonConvert.SerializeObject(output));
         return _hub.Clients.All.SendAsync("nextRound", output);

--- a/TonPrediction.Application/Output/NextRoundOutput.cs
+++ b/TonPrediction.Application/Output/NextRoundOutput.cs
@@ -22,4 +22,19 @@ public class NextRoundOutput
     /// 预测币种符号，如 ton、btc、eth。
     /// </summary>
     public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 当前价格。
+    /// </summary>
+    public string CurrentPrice { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 看涨赔率。
+    /// </summary>
+    public string BullOdds { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 看跌赔率。
+    /// </summary>
+    public string BearOdds { get; set; } = string.Empty;
 }

--- a/TonPrediction.Application/Services/Interface/IPredictionHubService.cs
+++ b/TonPrediction.Application/Services/Interface/IPredictionHubService.cs
@@ -18,11 +18,11 @@ public interface IPredictionHubService : ITransientDependency
     Task PushCurrentRoundAsync(RoundEntity round, decimal currentPrice);
 
     /// <summary>
-    /// 下个回合信息推送
+    /// 下个回合信息推送，包括奖池、倍率和价格等。
     /// </summary>
-    /// <param name="round"></param>
-    /// <param name="currentPrice"></param>
-    /// <returns></returns>
+    /// <param name="round">回合实体。</param>
+    /// <param name="currentPrice">当前价格。</param>
+    /// <returns>异步任务。</returns>
     Task PushNextRoundAsync(RoundEntity round, decimal currentPrice);
 
     /// <summary>


### PR DESCRIPTION
## Summary
- extend `NextRoundOutput` with price and odds
- update hub interface comment
- push detailed data for next round via SignalR

## Testing
- `dotnet format --verify-no-changes -v minimal`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686e1f8ff38883238c4460c61be99465