### PR TITLE
feat/round: add recent rounds api

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -323,3 +323,28 @@ GET /api/predictions/pnl
 | ------ | ---- | ---- |
 | `data` | bool | 是否上报成功 |
 
+## 1️⃣5️⃣ 最近回合及下注信息
+
+### `GET /api/rounds/recent?address=<ADDR>&symbol=ton&limit=3`
+
+返回指定用户最近若干回合及其下注情况。
+
+| 字段名 | 类型 | 说明 |
+| ------ | ---- | ---- |
+| `id` | int | 回合唯一编号 |
+| `epoch` | int | 期次（Epoch） |
+| `lockPrice` | string(decimal) | 锁定价格 |
+| `closePrice` | string(decimal) | 收盘价格 |
+| `totalAmount` | string(decimal) | 总下注金额 |
+| `bullAmount` | string(decimal) | 押 **上涨** 的金额 |
+| `bearAmount` | string(decimal) | 押 **下跌** 的金额 |
+| `rewardPool` | string(decimal) | 奖金池（扣手续费） |
+| `startTime` | int | 开始时间 |
+| `endTime` | int | 结束时间 |
+| `bullOdds` | string(decimal) | 上涨赔率 |
+| `bearOdds` | string(decimal) | 下跌赔率 |
+| `position` | enum | 用户下注方向，可能为 null |
+| `betAmount` | string(decimal) | 用户下注金额 |
+| `reward` | string(decimal) | 奖励金额 |
+| `claimed` | bool | 是否已领取 |
+

--- a/TonPrediction.Api/Controllers/RoundController.cs
+++ b/TonPrediction.Api/Controllers/RoundController.cs
@@ -31,4 +31,16 @@ public class RoundController(IRoundService roundService) : ControllerBase
     {
         return await _roundService.GetUpcomingAsync(symbol);
     }
+
+    /// <summary>
+    /// 获取最近回合及用户下注信息。
+    /// </summary>
+    [HttpGet("recent")]
+    public async Task<ApiResult<List<RoundUserBetOutput>>> GetRecentAsync(
+        [FromQuery] string address,
+        [FromQuery] string symbol = "ton",
+        [FromQuery] int limit = 3)
+    {
+        return await _roundService.GetRecentAsync(address, symbol, limit);
+    }
 }

--- a/TonPrediction.Application/Database/Repository/IBetRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IBetRepository.cs
@@ -59,6 +59,17 @@ namespace TonPrediction.Application.Database.Repository
             CancellationToken ct = default);
 
         /// <summary>
+        /// 根据地址和多个回合查询下注记录。
+        /// </summary>
+        /// <param name="address">用户地址。</param>
+        /// <param name="roundIds">回合编号集合。</param>
+        /// <param name="ct">取消令牌。</param>
+        Task<List<BetEntity>> GetByAddressAndRoundsAsync(
+            string address,
+            long[] roundIds,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// 根据交易哈希查询下注记录。
         /// </summary>
         /// <param name="txHash">交易哈希。</param>

--- a/TonPrediction.Application/Database/Repository/IRoundRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IRoundRepository.cs
@@ -53,6 +53,13 @@ namespace TonPrediction.Application.Database.Repository
         Task<List<RoundEntity>> GetEndedAsync(string symbol, int limit);
 
         /// <summary>
+        /// 获取最近若干回合（不限状态）。
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <param name="limit">限制数量。</param>
+        Task<List<RoundEntity>> GetRecentAsync(string symbol, int limit);
+
+        /// <summary>
         /// 获取回合信息通过回合编号。
         /// </summary>
         /// <param name="id"></param>

--- a/TonPrediction.Application/Output/RoundUserBetOutput.cs
+++ b/TonPrediction.Application/Output/RoundUserBetOutput.cs
@@ -1,0 +1,91 @@
+using System.Text.Json.Serialization;
+using TonPrediction.Application.Enums;
+
+namespace TonPrediction.Application.Output;
+
+/// <summary>
+/// 回合信息及用户下注详情。
+/// </summary>
+public class RoundUserBetOutput
+{
+    /// <summary>
+    /// 回合唯一编号，用于业务请求。
+    /// </summary>
+    [JsonPropertyName("id")]
+    public long RoundId { get; set; }
+
+    /// <summary>
+    /// 期次，从 1 开始递增。
+    /// </summary>
+    public long Epoch { get; set; }
+
+    /// <summary>
+    /// 锁定价格。
+    /// </summary>
+    public string LockPrice { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 收盘价格。
+    /// </summary>
+    public string ClosePrice { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 总下注金额。
+    /// </summary>
+    public string TotalAmount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 押看涨金额。
+    /// </summary>
+    public string BullAmount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 押看跌金额。
+    /// </summary>
+    public string BearAmount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 奖金池。
+    /// </summary>
+    public string RewardPool { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 开始时间 Unix 秒。
+    /// </summary>
+    public long StartTime { get; set; }
+
+    /// <summary>
+    /// 结束时间 Unix 秒。
+    /// </summary>
+    public long EndTime { get; set; }
+
+    /// <summary>
+    /// 看涨赔率。
+    /// </summary>
+    public string BullOdds { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 看跌赔率。
+    /// </summary>
+    public string BearOdds { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 用户下注方向，若未下注则为 null。
+    /// </summary>
+    public Position? Position { get; set; }
+
+    /// <summary>
+    /// 用户下注金额，未下注则为 "0"。
+    /// </summary>
+    public string BetAmount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 奖励金额，未中奖为 "0"。
+    /// </summary>
+    public string Reward { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 是否已领取奖励。
+    /// </summary>
+    public bool Claimed { get; set; }
+}

--- a/TonPrediction.Application/Services/Interface/IRoundService.cs
+++ b/TonPrediction.Application/Services/Interface/IRoundService.cs
@@ -30,4 +30,17 @@ public interface IRoundService : ITransientDependency
     Task<ApiResult<UpcomingRoundOutput>> GetUpcomingAsync(
         string symbol = "ton",
         CancellationToken ct = default);
+
+    /// <summary>
+    /// 获取最近回合以及用户下注信息。
+    /// </summary>
+    /// <param name="address">用户地址。</param>
+    /// <param name="symbol">币种符号。</param>
+    /// <param name="limit">返回数量限制。</param>
+    /// <param name="ct">取消任务标记。</param>
+    Task<ApiResult<List<RoundUserBetOutput>>> GetRecentAsync(
+        string address,
+        string symbol = "ton",
+        int limit = 3,
+        CancellationToken ct = default);
 }

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -15,10 +15,12 @@ namespace TonPrediction.Application.Services;
 /// </summary>
 public class RoundService(
     IRoundRepository roundRepo,
-    IConfiguration configuration) : IRoundService
+    IConfiguration configuration,
+    IBetRepository betRepo) : IRoundService
 {
     private readonly IRoundRepository _roundRepo = roundRepo;
     private readonly IConfiguration _configuration = configuration;
+    private readonly IBetRepository _betRepo = betRepo;
 
     /// <inheritdoc />
     public async Task<ApiResult<List<RoundHistoryOutput>>> GetHistoryAsync(
@@ -84,6 +86,52 @@ public class RoundService(
             EndTime = new DateTimeOffset(startTime.AddSeconds(intervalSec)).ToUnixTimeSeconds()
         };
         api.SetRsult(ApiResultCode.Success, fallback);
+        return api;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<RoundUserBetOutput>>> GetRecentAsync(
+        string address,
+        string symbol = "ton",
+        int limit = 3,
+        CancellationToken ct = default)
+    {
+        var api = new ApiResult<List<RoundUserBetOutput>>();
+        limit = limit is <= 0 or > 100 ? 3 : limit;
+        var rounds = await _roundRepo.GetRecentAsync(symbol, limit);
+        var roundIds = rounds.Select(r => r.Id).ToArray();
+        var bets = roundIds.Length == 0
+            ? new List<BetEntity>()
+            : await _betRepo.GetByAddressAndRoundsAsync(address, roundIds, ct);
+        var betMap = bets.ToDictionary(b => b.RoundId);
+
+        var list = new List<RoundUserBetOutput>();
+        foreach (var r in rounds)
+        {
+            betMap.TryGetValue(r.Id, out var bet);
+            var item = new RoundUserBetOutput
+            {
+                RoundId = r.Id,
+                Epoch = r.Epoch,
+                LockPrice = r.LockPrice.ToAmountString(),
+                ClosePrice = r.ClosePrice.ToAmountString(),
+                TotalAmount = r.TotalAmount.ToAmountString(),
+                BullAmount = r.BullAmount.ToAmountString(),
+                BearAmount = r.BearAmount.ToAmountString(),
+                RewardPool = r.RewardAmount.ToAmountString(),
+                StartTime = new DateTimeOffset(r.StartTime).ToUnixTimeSeconds(),
+                EndTime = new DateTimeOffset(r.CloseTime).ToUnixTimeSeconds(),
+                BullOdds = r.BullAmount > 0m ? (r.TotalAmount / r.BullAmount).ToAmountString() : "0",
+                BearOdds = r.BearAmount > 0m ? (r.TotalAmount / r.BearAmount).ToAmountString() : "0",
+                Position = bet?.Position,
+                BetAmount = bet?.Amount.ToAmountString() ?? "0",
+                Reward = bet?.Reward.ToAmountString() ?? "0",
+                Claimed = bet?.Claimed ?? false
+            };
+            list.Add(item);
+        }
+
+        api.SetRsult(ApiResultCode.Success, list);
         return api;
     }
 }

--- a/TonPrediction.Infrastructure/Database/Repository/BetRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/BetRepository.cs
@@ -79,5 +79,16 @@ namespace TonPrediction.Infrastructure.Database.Repository
                 .Where(b => b.UserAddress == address && b.RoundId == roundId)
                 .FirstAsync();
         }
+
+        /// <inheritdoc />
+        public async Task<List<BetEntity>> GetByAddressAndRoundsAsync(
+            string address,
+            long[] roundIds,
+            CancellationToken ct = default)
+        {
+            return await Db.Queryable<BetEntity>()
+                .Where(b => b.UserAddress == address && roundIds.Contains(b.RoundId))
+                .ToListAsync();
+        }
     }
 }

--- a/TonPrediction.Infrastructure/Database/Repository/RoundRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/RoundRepository.cs
@@ -80,6 +80,16 @@ namespace TonPrediction.Infrastructure.Database.Repository
                 .ToListAsync();
         }
 
+        /// <inheritdoc />
+        public async Task<List<RoundEntity>> GetRecentAsync(string symbol, int limit)
+        {
+            return await Db.Queryable<RoundEntity>()
+                .Where(r => r.Symbol == symbol)
+                .OrderBy(r => r.Epoch, OrderByType.Desc)
+                .Take(limit)
+                .ToListAsync();
+        }
+
         /// <summary>
         /// 获取回合信息通过回合编号。
         /// </summary>

--- a/TonPrediction.Test/RoundServiceTests.cs
+++ b/TonPrediction.Test/RoundServiceTests.cs
@@ -1,16 +1,76 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using TonPrediction.Application.Database.Entities;
+using TonPrediction.Application.Database.Repository;
+using TonPrediction.Application.Enums;
+using TonPrediction.Application.Services;
 using Xunit;
 
-namespace TonPrediction.Test
+namespace TonPrediction.Test;
+
+/// <summary>
+/// RoundService 最近回合接口测试。
+/// </summary>
+public class RoundServiceTests
 {
-    /// <summary>
-    /// 回合服务测试占位。
-    /// </summary>
-    public class RoundServiceTests
+    [Fact]
+    public async Task GetRecentAsync_ReturnsRoundsWithBetInfo()
     {
-        /// <summary>
-        /// 占位测试，待后续补充。
-        /// </summary>
-        [Fact(Skip = "Not implemented")]
-        public void Placeholder() { }
+        var rounds = new List<RoundEntity>
+        {
+            new()
+            {
+                Id = 1,
+                Epoch = 1,
+                StartTime = DateTime.UtcNow.AddMinutes(-10),
+                CloseTime = DateTime.UtcNow.AddMinutes(-5),
+                LockPrice = 1m,
+                ClosePrice = 1.2m,
+                TotalAmount = 100m,
+                BullAmount = 60m,
+                BearAmount = 40m,
+                RewardAmount = 95m
+            },
+            new()
+            {
+                Id = 2,
+                Epoch = 2,
+                StartTime = DateTime.UtcNow.AddMinutes(-5),
+                CloseTime = DateTime.UtcNow,
+                LockPrice = 1.2m,
+                ClosePrice = 1.1m,
+                TotalAmount = 80m,
+                BullAmount = 30m,
+                BearAmount = 50m,
+                RewardAmount = 76m
+            }
+        };
+
+        var bets = new List<BetEntity>
+        {
+            new()
+            {
+                RoundId = 1,
+                UserAddress = "addr",
+                Amount = 10m,
+                Position = Position.Bull,
+                Claimed = false,
+                Reward = 20m
+            }
+        };
+
+        var roundRepo = new Mock<IRoundRepository>();
+        roundRepo.Setup(r => r.GetRecentAsync("ton", 2)).ReturnsAsync(rounds);
+        var betRepo = new Mock<IBetRepository>();
+        betRepo.Setup(b => b.GetByAddressAndRoundsAsync("addr", It.IsAny<long[]>(), default))
+            .ReturnsAsync(bets);
+        var service = new RoundService(roundRepo.Object, new ConfigurationBuilder().Build(), betRepo.Object);
+
+        var result = await service.GetRecentAsync("addr", "ton", 2);
+
+        Assert.Equal(2, result.Data.Count);
+        Assert.Equal("10", result.Data[0].BetAmount);
     }
 }


### PR DESCRIPTION
## Summary
- add RoundUserBetOutput to report round data with user bet info
- extend RoundService and repositories to support recent rounds query
- expose `GET /api/rounds/recent` endpoint
- document the new API in TON Prediction API doc
- add unit test for RoundService

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686e2356af98832396094d8fe2a3c9bb