### PR TITLE
chore: refine websocket payloads

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -45,7 +45,7 @@
 >await hub.start();
 > ```
 >
->**说明**：回合相关响应均同时包含 `id` 与 `epoch` 字段，`id` 用于后续业务请求，`epoch` 用于展示回合期次。
+>**说明**：除 `currentRound` 与 `nextRound` 外，其他回合相关响应均同时包含 `id` 与 `epoch` 字段，`id` 用于后续业务请求，`epoch` 用于展示回合期次。
 
 ------
 
@@ -55,35 +55,27 @@
 
 - **推送频率**：每 5 秒（或当有下注 / 价格变化时实时推送）
 
-| 字段名         | 类型            | 说明                                     |
-| -------------- | --------------- | ---------------------------------------- |
-| `id`      | int             | 回合唯一编号                                 |
-| `epoch`   | int             | 期次（Epoch）                                 |
-| `lockPrice`    | string(decimal) | 锁定价格                                 |
-| `currentPrice` | string(decimal) | 最新价格                                 |
-| `totalAmount`  | string(decimal) | 总下注金额                               |
-| `bullAmount` | string(decimal) | 押 **上涨** 的金额                       |
-| `bearAmount` | string(decimal) | 押 **下跌** 的金额                       |
-| `rewardPool`   | string(decimal) | 扣除手续费后的可分配奖金池               |
-| `endTime`      | int             | 回合结束时间（Unix 秒）                  |
-| `bullOdds`  | string(decimal) | 上涨赔率 = `totalAmount / bullAmount`    |
-| `bearOdds` | string(decimal) | 下跌赔率 = `totalAmount / bearAmount`   |
-| `status`       | enum            | `upcoming` |
+| 字段名       | 类型            | 说明                                   |
+| ------------ | --------------- | -------------------------------------- |
+| `id`         | int             | 回合唯一编号                           |
+| `currentPrice` | string(decimal) | 最新价格                               |
+| `totalAmount`  | string(decimal) | 总下注金额                             |
+| `bullAmount`   | string(decimal) | 押 **上涨** 的金额                     |
+| `bearAmount`   | string(decimal) | 押 **下跌** 的金额                     |
+| `rewardPool`   | string(decimal) | 扣除手续费后的可分配奖金池             |
+| `bullOdds`     | string(decimal) | 上涨赔率 = `totalAmount / bullAmount` |
+| `bearOdds`     | string(decimal) | 下跌赔率 = `totalAmount / bearAmount` |
 
 **示例：**
 
 ```json
 {
   "id": 357690,
-  "epoch": 357690,
-  "lockPrice": "308.85",
   "currentPrice": "309.125",
   "totalAmount": "2500",
   "bullAmount": "1400",
   "bearAmount": "1100",
   "rewardPool": "2425",
-  "endTime": 1710001234,
-  "status": "live",
   "bullOdds": "1.78571428",
   "bearOdds": "2.20454545"
 }
@@ -97,13 +89,17 @@
 
 - **推送频率**：下注变动时实时推送
 
-仅推送下个回合的奖池变化，字段如下：
+仅推送下个回合实时变化的字段：
 
-| 字段名       | 类型            | 说明                     |
-| ------------ | --------------- | ------------------------ |
-| `id`         | int             | 回合唯一编号             |
-| `rewardPool` | string(decimal) | 扣除手续费后的可分配奖金 |
-| `symbol`     | string          | 币种符号，如 `ton`       |
+| 字段名       | 类型            | 说明                                   |
+| ------------ | --------------- | -------------------------------------- |
+| `id`         | int             | 回合唯一编号                           |
+| `totalAmount`| string(decimal) | 总下注金额                             |
+| `bullAmount` | string(decimal) | 押 **上涨** 的金额                     |
+| `bearAmount` | string(decimal) | 押 **下跌** 的金额                     |
+| `rewardPool` | string(decimal) | 扣除手续费后的可分配奖金               |
+| `bullOdds`   | string(decimal) | 上涨赔率 = `totalAmount / bullAmount` |
+| `bearOdds`   | string(decimal) | 下跌赔率 = `totalAmount / bearAmount` |
 
 ------
 

--- a/TonPrediction.Api/Services/PredictionHubService.cs
+++ b/TonPrediction.Api/Services/PredictionHubService.cs
@@ -28,17 +28,13 @@ public class PredictionHubService(ILogger<PredictionHubService> logger, IHubCont
         var output = new CurrentRoundOutput
         {
             RoundId = round.Id,
-            Epoch = round.Epoch,
-            LockPrice = round.LockPrice.ToAmountString(),
             CurrentPrice = currentPrice.ToAmountString(),
             TotalAmount = round.TotalAmount.ToAmountString(),
             BullAmount = round.BullAmount.ToAmountString(),
             BearAmount = round.BearAmount.ToAmountString(),
             RewardPool = round.RewardAmount.ToAmountString(),
-            EndTime = new DateTimeOffset(round.CloseTime).ToUnixTimeSeconds(),
             BullOdds = oddsBull.ToAmountString(),
-            BearOdds = oddsBear.ToAmountString(),
-            Status = round.Status
+            BearOdds = oddsBear.ToAmountString()
         };
         logger.LogInformation("PushCurrentRoundAsync.当前回合信息推送:{output}", JsonConvert.SerializeObject(output));
         return _hub.Clients.All.SendAsync("currentRound", output);
@@ -58,9 +54,10 @@ public class PredictionHubService(ILogger<PredictionHubService> logger, IHubCont
         var output = new NextRoundOutput
         {
             RoundId = round.Id,
+            TotalAmount = round.TotalAmount.ToAmountString(),
+            BullAmount = round.BullAmount.ToAmountString(),
+            BearAmount = round.BearAmount.ToAmountString(),
             RewardPool = round.RewardAmount.ToAmountString(),
-            Symbol = round.Symbol,
-            CurrentPrice = currentPrice.ToAmountString(),
             BullOdds = oddsBull.ToAmountString(),
             BearOdds = oddsBear.ToAmountString()
         };
@@ -94,7 +91,7 @@ public class PredictionHubService(ILogger<PredictionHubService> logger, IHubCont
         logger.LogInformation("PushRoundLockedAsync.锁定回合推送:{output}", JsonConvert.SerializeObject(output));
         return _hub.Clients.All.SendAsync("roundLocked", output);
     }
-       
+
 
     /// <summary>
     /// 推送开始结算消息
@@ -108,7 +105,7 @@ public class PredictionHubService(ILogger<PredictionHubService> logger, IHubCont
         logger.LogInformation("PushSettlementStartedAsync.推送开始结算消息:{output}", JsonConvert.SerializeObject(output));
         return _hub.Clients.All.SendAsync("settlementStarted", output);
     }
-       
+
 
     /// <summary>
     /// 回合结束

--- a/TonPrediction.Application/Output/CurrentRoundOutput.cs
+++ b/TonPrediction.Application/Output/CurrentRoundOutput.cs
@@ -15,16 +15,6 @@ public class CurrentRoundOutput
     public long RoundId { get; set; }
 
     /// <summary>
-    /// 期次，从 1 开始递增。
-    /// </summary>
-    public long Epoch { get; set; }
-
-    /// <summary>
-    /// 锁定价格。
-    /// </summary>
-    public string LockPrice { get; set; } = string.Empty;
-
-    /// <summary>
     /// 最新价格。
     /// </summary>
     public string CurrentPrice { get; set; } = string.Empty;
@@ -50,11 +40,6 @@ public class CurrentRoundOutput
     public string RewardPool { get; set; } = string.Empty;
 
     /// <summary>
-    /// 结束时间 Unix 秒。
-    /// </summary>
-    public long EndTime { get; set; }
-
-    /// <summary>
     /// 看涨赔率。
     /// </summary>
     public string BullOdds { get; set; } = string.Empty;
@@ -63,9 +48,4 @@ public class CurrentRoundOutput
     /// 看跌赔率。
     /// </summary>
     public string BearOdds { get; set; } = string.Empty;
-
-    /// <summary>
-    /// 回合状态。
-    /// </summary>
-    public RoundStatus Status { get; set; }
 }

--- a/TonPrediction.Application/Output/NextRoundOutput.cs
+++ b/TonPrediction.Application/Output/NextRoundOutput.cs
@@ -14,19 +14,24 @@ public class NextRoundOutput
     public long RoundId { get; set; }
 
     /// <summary>
+    /// 总下注金额。
+    /// </summary>
+    public string TotalAmount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 押看涨金额。
+    /// </summary>
+    public string BullAmount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 押看跌金额。
+    /// </summary>
+    public string BearAmount { get; set; } = string.Empty;
+
+    /// <summary>
     /// 奖池金额，扣除手续费后可分配的奖励。
     /// </summary>
     public string RewardPool { get; set; } = string.Empty;
-
-    /// <summary>
-    /// 预测币种符号，如 ton、btc、eth。
-    /// </summary>
-    public string Symbol { get; set; } = string.Empty;
-
-    /// <summary>
-    /// 当前价格。
-    /// </summary>
-    public string CurrentPrice { get; set; } = string.Empty;
 
     /// <summary>
     /// 看涨赔率。


### PR DESCRIPTION
## Summary
- shrink `currentRound`/`nextRound` payloads to only send realtime fields
- update API documentation

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686e2744a7fc832385631c0515c6f420