### PR TITLE
feat(rounds): allow empty address on recent

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -321,9 +321,9 @@ GET /api/predictions/pnl
 
 ## 1️⃣5️⃣ 最近回合及下注信息
 
-### `GET /api/rounds/recent?address=<ADDR>&symbol=ton&limit=3`
+### `GET /api/rounds/recent?symbol=ton&limit=3&address=<ADDR>`
 
-返回指定用户最近若干回合及其下注情况。
+返回最近若干回合及（可选）指定地址的下注情况，未传地址时仅返回回合信息。
 
 | 字段名 | 类型 | 说明 |
 | ------ | ---- | ---- |

--- a/TonPrediction.Api/Controllers/RoundController.cs
+++ b/TonPrediction.Api/Controllers/RoundController.cs
@@ -38,7 +38,7 @@ public class RoundController(IRoundService roundService) : ControllerBase
     /// 获取最近回合及用户下注信息。
     /// </summary>
     [HttpGet("recent")]
-    public async Task<ApiResult<List<RoundUserBetOutput>>> GetRecentAsync([FromQuery] string address, [FromQuery] string symbol = "ton", [FromQuery] int limit = 5)
+    public async Task<ApiResult<List<RoundUserBetOutput>>> GetRecentAsync([FromQuery] string? address, [FromQuery] string symbol = "ton", [FromQuery] int limit = 5)
     {
         return await _roundService.GetRecentAsync(address, symbol, limit);
     }

--- a/TonPrediction.Application/Services/Interface/IRoundService.cs
+++ b/TonPrediction.Application/Services/Interface/IRoundService.cs
@@ -34,12 +34,12 @@ public interface IRoundService : ITransientDependency
     /// <summary>
     /// 获取最近回合以及用户下注信息。
     /// </summary>
-    /// <param name="address">用户地址。</param>
+    /// <param name="address">用户地址，可为空。</param>
     /// <param name="symbol">币种符号。</param>
     /// <param name="limit">返回数量限制。</param>
     /// <param name="ct">取消任务标记。</param>
     Task<ApiResult<List<RoundUserBetOutput>>> GetRecentAsync(
-        string address,
+        string? address,
         string symbol = "ton",
         int limit = 5,
         CancellationToken ct = default);

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -98,7 +98,7 @@ public class RoundService(
     /// <param name="ct"></param>
     /// <returns></returns>
     public async Task<ApiResult<List<RoundUserBetOutput>>> GetRecentAsync(
-        string address,
+        string? address,
         string symbol = "ton",
         int limit = 5,
         CancellationToken ct = default)
@@ -107,9 +107,9 @@ public class RoundService(
         limit = limit is <= 0 or > 100 ? 3 : limit;
         var rounds = await _roundRepo.GetRecentAsync(symbol, limit);
         var roundIds = rounds.Select(r => r.Id).ToArray();
-        var bets = roundIds.Length == 0
+        var bets = roundIds.Length == 0 || string.IsNullOrWhiteSpace(address)
             ? new List<BetEntity>()
-            : await _betRepo.GetByAddressAndRoundsAsync(address, roundIds, ct);
+            : await _betRepo.GetByAddressAndRoundsAsync(address!, roundIds, ct);
         var betMap = bets.ToDictionary(b => b.RoundId);
 
         var list = new List<RoundUserBetOutput>();

--- a/TonPrediction.Test/RoundServiceTests.cs
+++ b/TonPrediction.Test/RoundServiceTests.cs
@@ -73,4 +73,35 @@ public class RoundServiceTests
         Assert.Equal(2, result.Data.Count);
         Assert.Equal("10", result.Data[0].BetAmount);
     }
+
+    [Fact]
+    public async Task GetRecentAsync_WithoutAddress_ReturnsRoundsOnly()
+    {
+        var rounds = new List<RoundEntity>
+        {
+            new()
+            {
+                Id = 1,
+                Epoch = 1,
+                StartTime = DateTime.UtcNow.AddMinutes(-10),
+                CloseTime = DateTime.UtcNow.AddMinutes(-5),
+                LockPrice = 1m,
+                ClosePrice = 1.2m,
+                TotalAmount = 100m,
+                BullAmount = 60m,
+                BearAmount = 40m,
+                RewardAmount = 95m
+            }
+        };
+
+        var roundRepo = new Mock<IRoundRepository>();
+        roundRepo.Setup(r => r.GetRecentAsync("ton", 1)).ReturnsAsync(rounds);
+        var betRepo = new Mock<IBetRepository>();
+        var service = new RoundService(roundRepo.Object, new ConfigurationBuilder().Build(), betRepo.Object);
+
+        var result = await service.GetRecentAsync(null, "ton", 1);
+
+        Assert.Single(result.Data);
+        Assert.Equal("0", result.Data[0].BetAmount);
+    }
 }


### PR DESCRIPTION
## Summary
- support missing `address` on `/api/rounds/recent`
- implement service logic for null address
- document optional `address` query parameter
- add test for null address scenario

## Testing
- `dotnet format --verify-no-changes -v diag`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686e2b77372883238eafc4644f60f591