### PR TITLE
feat/predictions-round-pnl

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -252,17 +252,24 @@ GET /api/predictions/round
 
 **data[] 字段：**
 
-| 字段名       | 类型            | 说明                    |
-| ------------ | --------------- | ----------------------- |
-| `id`    | int             | 回合唯一编号                |
-| `epoch` | int             | 期次（Epoch）                |
-| `position`   | enum            | `up` | `down`           |
-| `amount`     | string(decimal) | 押注金额                |
-| `lockPrice`  | string(decimal) | 锁定价格                |
-| `closePrice` | string(decimal) | 收盘价格                |
-| `reward`     | string(decimal) | 奖励（可能为 0）        |
-| `claimed`    | bool            | 是否已领取              |
-| `result`     | enum            | `win` | `lose` | `draw` |
+| 字段名 | 类型 | 说明 |
+| ------ | ---- | ---- |
+| `id` | int | 回合唯一编号 |
+| `epoch` | int | 期次（Epoch） |
+| `lockPrice` | string(decimal) | 锁定价格 |
+| `closePrice` | string(decimal) | 收盘价格 |
+| `totalAmount` | string(decimal) | 总下注金额 |
+| `bullAmount` | string(decimal) | 押 **上涨** 的金额 |
+| `bearAmount` | string(decimal) | 押 **下跌** 的金额 |
+| `rewardPool` | string(decimal) | 奖金池（扣手续费） |
+| `startTime` | int | 开始时间 |
+| `endTime` | int | 结束时间 |
+| `bullOdds` | string(decimal) | 上涨赔率 |
+| `bearOdds` | string(decimal) | 下跌赔率 |
+| `position` | enum | 用户下注方向，可能为 null |
+| `betAmount` | string(decimal) | 用户下注金额 |
+| `reward` | string(decimal) | 奖励金额 |
+| `claimed` | bool | 是否已领取 |
 
 ### mode = `pnl`
 
@@ -270,7 +277,21 @@ GET /api/predictions/round
 GET /api/predictions/pnl
 ```
 
-返回盈亏汇总，字段同现有文档，字段名保持不变。
+返回盈亏汇总：
+
+| 字段名 | 类型 | 说明 |
+| ------ | ---- | ---- |
+| `totalBet` | string(decimal) | 累计下注金额 |
+| `totalReward` | string(decimal) | 累计奖励金额 |
+| `netProfit` | string(decimal) | 最终盈亏 |
+| `rounds` | int | 参与回合数 |
+| `winRounds` | int | 获胜回合数 |
+| `loseRounds` | int | 失利回合数 |
+| `winRate` | string | 胜率（0-1） |
+| `averageBet` | string(decimal) | 平均投入/回合 |
+| `averageReturn` | string(decimal) | 平均奖励/回合 |
+| `bestRoundId` | int | 最佳回合编号 |
+| `bestRoundProfit` | string(decimal) | 最佳回合收益 |
 
 ------
 

--- a/TonPrediction.Api/Controllers/PredictionsController.cs
+++ b/TonPrediction.Api/Controllers/PredictionsController.cs
@@ -18,7 +18,7 @@ public class PredictionsController(IPredictionService predictionService) : Contr
     /// 分页获取下注记录。
     /// </summary>
     [HttpGet("round")]
-    public async Task<ApiResult<List<BetRecordOutput>>> GetRoundAsync(
+    public async Task<ApiResult<List<RoundUserBetOutput>>> GetRoundAsync(
         [FromQuery] string address,
         [FromQuery] string status = "all",
         [FromQuery] int page = 1,

--- a/TonPrediction.Application/Output/PnlOutput.cs
+++ b/TonPrediction.Application/Output/PnlOutput.cs
@@ -29,4 +29,34 @@ public class PnlOutput
     /// 获胜回合数。
     /// </summary>
     public int WinRounds { get; set; }
+
+    /// <summary>
+    /// 失利回合数。
+    /// </summary>
+    public int LoseRounds { get; set; }
+
+    /// <summary>
+    /// 胜率（0-1）。
+    /// </summary>
+    public string WinRate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 回合平均投入。
+    /// </summary>
+    public string AverageBet { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 回合平均收益。
+    /// </summary>
+    public string AverageReturn { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 最佳回合编号。
+    /// </summary>
+    public long BestRoundId { get; set; }
+
+    /// <summary>
+    /// 最佳回合收益。
+    /// </summary>
+    public string BestRoundProfit { get; set; } = string.Empty;
 }

--- a/TonPrediction.Application/Services/Interface/IPredictionService.cs
+++ b/TonPrediction.Application/Services/Interface/IPredictionService.cs
@@ -17,8 +17,8 @@ public interface IPredictionService : ITransientDependency
     /// <param name="page">页码。</param>
     /// <param name="pageSize">每页条数。</param>
     /// <param name="ct">取消任务标记。</param>
-    /// <returns>下注记录列表。</returns>
-    Task<ApiResult<List<BetRecordOutput>>> GetRecordsAsync(
+    /// <returns>回合及下注信息列表。</returns>
+    Task<ApiResult<List<RoundUserBetOutput>>> GetRecordsAsync(
         string address,
         string status = "all",
         int page = 1,


### PR DESCRIPTION
## Summary
- expand `/predictions/round` to include round details
- enhance `GetPnlAsync` with win/loss statistics and best round info
- document updated output fields for round and pnl APIs

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686e2e5efa5c8323988777b0f097633e