### PR TITLE
feat: add symbol filter for pnl and leaderboard

### DIFF
--- a/TonPrediction.Api/Controllers/LeaderboardController.cs
+++ b/TonPrediction.Api/Controllers/LeaderboardController.cs
@@ -19,11 +19,12 @@ public class LeaderboardController(ILeaderboardService service) : ControllerBase
     /// </summary>
     [HttpGet("list")]
     public async Task<ApiResult<LeaderboardOutput>> GetListAsync(
+        [FromQuery] string symbol = "ton",
         [FromQuery] string rankBy = "netProfit",
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10,
         [FromQuery] string? address = null)
     {
-        return await _service.GetListAsync(rankBy, page, pageSize, address);
+        return await _service.GetListAsync(symbol, rankBy, page, pageSize, address);
     }
 }

--- a/TonPrediction.Api/Controllers/PredictionsController.cs
+++ b/TonPrediction.Api/Controllers/PredictionsController.cs
@@ -31,8 +31,10 @@ public class PredictionsController(IPredictionService predictionService) : Contr
     /// 获取盈亏汇总。
     /// </summary>
     [HttpGet("pnl")]
-    public async Task<ApiResult<PnlOutput>> GetPnlAsync([FromQuery] string address)
+    public async Task<ApiResult<PnlOutput>> GetPnlAsync(
+        [FromQuery] string address,
+        [FromQuery] string symbol = "ton")
     {
-        return await _predictionService.GetPnlAsync(address);
+        return await _predictionService.GetPnlAsync(symbol, address);
     }
 }

--- a/TonPrediction.Api/Services/RoundScheduler.cs
+++ b/TonPrediction.Api/Services/RoundScheduler.cs
@@ -177,13 +177,14 @@ namespace TonPrediction.Api.Services
                     bet.Reward = reward;
                     await betRepo.UpdateByPrimaryKeyAsync(bet);
 
-                    var stat = await statRepo.GetByAddressAsync(bet.UserAddress);
+                    var stat = await statRepo.GetByAddressAsync(symbol, bet.UserAddress);
                     var profit = reward - bet.Amount;
                     var win = reward > 0m;
                     if (stat == null)
                     {
                         stat = new PnlStatEntity
                         {
+                            Symbol = symbol,
                             UserAddress = bet.UserAddress,
                             TotalBet = bet.Amount,
                             TotalReward = reward,

--- a/TonPrediction.Application/Database/Entities/PnlStatEntity.cs
+++ b/TonPrediction.Application/Database/Entities/PnlStatEntity.cs
@@ -9,6 +9,11 @@ namespace TonPrediction.Application.Database.Entities;
 public class PnlStatEntity
 {
     /// <summary>
+    /// 预测币种符号，主键之一。
+    /// </summary>
+    [SugarColumn(IsPrimaryKey = true, ColumnName = "symbol", Length = 16)]
+    public string Symbol { get; set; } = string.Empty;
+    /// <summary>
     /// 用户地址，主键。
     /// </summary>
     [SugarColumn(IsPrimaryKey = true, ColumnName = "user_address")]

--- a/TonPrediction.Application/Database/Repository/IPnlStatRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IPnlStatRepository.cs
@@ -12,21 +12,24 @@ public interface IPnlStatRepository : IBaseRepository<PnlStatEntity>, ITransient
     /// <summary>
     /// 根据地址获取统计记录。
     /// </summary>
+    /// <param name="symbol">币种符号。</param>
     /// <param name="address">用户地址。</param>
-    Task<PnlStatEntity?> GetByAddressAsync(string address);
+    Task<PnlStatEntity?> GetByAddressAsync(string symbol, string address);
 
     /// <summary>
     /// 分页获取排行榜数据。
     /// </summary>
+    /// <param name="symbol">币种符号。</param>
     /// <param name="rankBy">排序字段。</param>
     /// <param name="page">页码。</param>
     /// <param name="pageSize">分页大小。</param>
-    Task<List<PnlStatEntity>> GetPagedAsync(string rankBy, int page, int pageSize);
+    Task<List<PnlStatEntity>> GetPagedAsync(string symbol, string rankBy, int page, int pageSize);
 
     /// <summary>
     /// 获取指定地址的排名。
     /// </summary>
+    /// <param name="symbol">币种符号。</param>
     /// <param name="address">用户地址。</param>
     /// <param name="rankBy">排序字段。</param>
-    Task<int> GetRankAsync(string address, string rankBy);
+    Task<int> GetRankAsync(string symbol, string address, string rankBy);
 }

--- a/TonPrediction.Application/Services/Interface/ILeaderboardService.cs
+++ b/TonPrediction.Application/Services/Interface/ILeaderboardService.cs
@@ -17,6 +17,7 @@ public interface ILeaderboardService : ITransientDependency
     /// <param name="pageSize">分页大小。</param>
     /// <param name="address">可选地址。</param>
     Task<ApiResult<LeaderboardOutput>> GetListAsync(
+        string symbol = "ton",
         string rankBy = "netProfit",
         int page = 1,
         int pageSize = 10,

--- a/TonPrediction.Application/Services/Interface/IPredictionService.cs
+++ b/TonPrediction.Application/Services/Interface/IPredictionService.cs
@@ -28,7 +28,8 @@ public interface IPredictionService : ITransientDependency
     /// <summary>
     /// 获取指定地址的盈亏汇总。
     /// </summary>
+    /// <param name="symbol">币种符号。</param>
     /// <param name="address">用户地址。</param>
     /// <returns>盈亏信息。</returns>
-    Task<ApiResult<PnlOutput>> GetPnlAsync(string address);
+    Task<ApiResult<PnlOutput>> GetPnlAsync(string symbol, string address);
 }

--- a/TonPrediction.Application/Services/LeaderboardService.cs
+++ b/TonPrediction.Application/Services/LeaderboardService.cs
@@ -15,6 +15,7 @@ public class LeaderboardService(IPnlStatRepository repo) : ILeaderboardService
 
     /// <inheritdoc />
     public async Task<ApiResult<LeaderboardOutput>> GetListAsync(
+        string symbol = "ton",
         string rankBy = "netProfit",
         int page = 1,
         int pageSize = 10,
@@ -23,7 +24,7 @@ public class LeaderboardService(IPnlStatRepository repo) : ILeaderboardService
         var api = new ApiResult<LeaderboardOutput>();
         page = page <= 0 ? 1 : page;
         pageSize = pageSize is <= 0 or > 100 ? 10 : pageSize;
-        var stats = await _repo.GetPagedAsync(rankBy, page, pageSize);
+        var stats = await _repo.GetPagedAsync(symbol, rankBy, page, pageSize);
         var list = new List<LeaderboardItemOutput>();
         for (var i = 0; i < stats.Count; i++)
         {
@@ -45,7 +46,7 @@ public class LeaderboardService(IPnlStatRepository repo) : ILeaderboardService
         var output = new LeaderboardOutput { List = list };
         if (!string.IsNullOrWhiteSpace(address))
         {
-            var rank = await _repo.GetRankAsync(address, rankBy);
+            var rank = await _repo.GetRankAsync(symbol, address, rankBy);
             if (rank > 0)
             {
                 output.AddressRank = rank;


### PR DESCRIPTION
## Summary
- support symbol-filtered leaderboard and pnl stats
- query pnl stats directly instead of recalculating
- update round scheduler stat records

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686e38b5d6bc832397859bc52fb64b49