### PR TITLE
feat(round): return status in recent api

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -264,6 +264,7 @@ GET /api/predictions/round
 | `rewardPool` | string(decimal) | 奖金池（扣手续费） |
 | `startTime` | int | 开始时间 |
 | `endTime` | int | 结束时间 |
+| `status` | enum | 回合状态 |
 | `bullOdds` | string(decimal) | 上涨赔率 |
 | `bearOdds` | string(decimal) | 下跌赔率 |
 | `position` | enum | 用户下注方向，可能为 null |

--- a/TonPrediction.Application/Output/RoundUserBetOutput.cs
+++ b/TonPrediction.Application/Output/RoundUserBetOutput.cs
@@ -60,6 +60,11 @@ public class RoundUserBetOutput
     public long EndTime { get; set; }
 
     /// <summary>
+    /// 回合当前状态。
+    /// </summary>
+    public RoundStatus Status { get; set; }
+
+    /// <summary>
     /// 看涨赔率。
     /// </summary>
     public string BullOdds { get; set; } = string.Empty;

--- a/TonPrediction.Application/Services/PredictionService.cs
+++ b/TonPrediction.Application/Services/PredictionService.cs
@@ -67,6 +67,7 @@ public class PredictionService(
                 RewardPool = round.RewardAmount.ToAmountString(),
                 StartTime = new DateTimeOffset(round.StartTime).ToUnixTimeSeconds(),
                 EndTime = new DateTimeOffset(round.CloseTime).ToUnixTimeSeconds(),
+                Status = round.Status,
                 BullOdds = round.BullAmount > 0m ? (round.TotalAmount / round.BullAmount).ToAmountString() : "0",
                 BearOdds = round.BearAmount > 0m ? (round.TotalAmount / round.BearAmount).ToAmountString() : "0",
                 Position = bet.Position,

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -128,6 +128,7 @@ public class RoundService(
                 RewardPool = r.RewardAmount.ToAmountString(),
                 StartTime = new DateTimeOffset(r.StartTime).ToUnixTimeSeconds(),
                 EndTime = new DateTimeOffset(r.CloseTime).ToUnixTimeSeconds(),
+                Status = r.Status,
                 BullOdds = r.BullAmount > 0m ? (r.TotalAmount / r.BullAmount).ToAmountString() : "0",
                 BearOdds = r.BearAmount > 0m ? (r.TotalAmount / r.BearAmount).ToAmountString() : "0",
                 Position = bet?.Position,

--- a/TonPrediction.Test/RoundServiceTests.cs
+++ b/TonPrediction.Test/RoundServiceTests.cs
@@ -31,7 +31,8 @@ public class RoundServiceTests
                 TotalAmount = 100m,
                 BullAmount = 60m,
                 BearAmount = 40m,
-                RewardAmount = 95m
+                RewardAmount = 95m,
+                Status = RoundStatus.Completed
             },
             new()
             {
@@ -44,7 +45,8 @@ public class RoundServiceTests
                 TotalAmount = 80m,
                 BullAmount = 30m,
                 BearAmount = 50m,
-                RewardAmount = 76m
+                RewardAmount = 76m,
+                Status = RoundStatus.Locked
             }
         };
 
@@ -72,6 +74,8 @@ public class RoundServiceTests
 
         Assert.Equal(2, result.Data.Count);
         Assert.Equal("10", result.Data[0].BetAmount);
+        Assert.Equal(RoundStatus.Completed, result.Data[0].Status);
+        Assert.Equal(RoundStatus.Locked, result.Data[1].Status);
     }
 
     [Fact]
@@ -90,7 +94,8 @@ public class RoundServiceTests
                 TotalAmount = 100m,
                 BullAmount = 60m,
                 BearAmount = 40m,
-                RewardAmount = 95m
+                RewardAmount = 95m,
+                Status = RoundStatus.Completed
             }
         };
 
@@ -103,5 +108,6 @@ public class RoundServiceTests
 
         Assert.Single(result.Data);
         Assert.Equal("0", result.Data[0].BetAmount);
+        Assert.Equal(RoundStatus.Completed, result.Data[0].Status);
     }
 }


### PR DESCRIPTION
## Summary
- include round status in `RoundUserBetOutput`
- map `Status` in `RoundService` and `PredictionService`
- update `recent` endpoint docs
- adjust unit tests for new field

## Related Issue
- User request to expose round status in recent API

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686f1abd74f883239efba485dd653033