### PR TITLE
Use enum for Prediction status filter

### DIFF
--- a/TonPrediction.Api/Controllers/PredictionsController.cs
+++ b/TonPrediction.Api/Controllers/PredictionsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using QYQ.Base.Common.ApiResult;
 using TonPrediction.Application.Output;
+using TonPrediction.Application.Enums;
 using TonPrediction.Application.Services.Interface;
 
 namespace TonPrediction.Api.Controllers;
@@ -20,7 +21,7 @@ public class PredictionsController(IPredictionService predictionService) : Contr
     [HttpGet("round")]
     public async Task<ApiResult<List<RoundUserBetOutput>>> GetRoundAsync(
         [FromQuery] string address,
-        [FromQuery] string status = "all",
+        [FromQuery] BetRecordStatus status = BetRecordStatus.All,
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 10)
     {

--- a/TonPrediction.Application/Database/Repository/IBetRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IBetRepository.cs
@@ -4,6 +4,7 @@ using QYQ.Base.SqlSugar;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -18,13 +19,13 @@ namespace TonPrediction.Application.Database.Repository
         /// 获取指定地址的分页下注记录。
         /// </summary>
         /// <param name="address">用户地址。</param>
-        /// <param name="status">记录状态过滤。</param>
+        /// <param name="predicate">额外的筛选条件。</param>
         /// <param name="page">页码。</param>
         /// <param name="pageSize">每页数量。</param>
         /// <param name="ct">取消令牌。</param>
         Task<List<BetEntity>> GetPagedByAddressAsync(
             string address,
-            string status,
+            Expression<Func<BetEntity, bool>>? predicate,
             int page,
             int pageSize,
             CancellationToken ct = default);

--- a/TonPrediction.Application/Enums/BetRecordStatus.cs
+++ b/TonPrediction.Application/Enums/BetRecordStatus.cs
@@ -1,0 +1,22 @@
+namespace TonPrediction.Application.Enums;
+
+/// <summary>
+/// 下注记录筛选状态。
+/// </summary>
+public enum BetRecordStatus
+{
+    /// <summary>
+    /// 全部记录。
+    /// </summary>
+    All = 0,
+
+    /// <summary>
+    /// 已领取奖励的记录。
+    /// </summary>
+    Claimed = 1,
+
+    /// <summary>
+    /// 未领取奖励的记录。
+    /// </summary>
+    Unclaimed = 2
+}

--- a/TonPrediction.Application/Services/Interface/IPredictionService.cs
+++ b/TonPrediction.Application/Services/Interface/IPredictionService.cs
@@ -1,6 +1,7 @@
 using QYQ.Base.Common.IOCExtensions;
 using QYQ.Base.Common.ApiResult;
 using TonPrediction.Application.Output;
+using TonPrediction.Application.Enums;
 
 namespace TonPrediction.Application.Services.Interface;
 
@@ -13,14 +14,14 @@ public interface IPredictionService : ITransientDependency
     /// 分页获取指定地址的下注记录。
     /// </summary>
     /// <param name="address">用户地址。</param>
-    /// <param name="status">记录状态：all/claimed/unclaimed。</param>
+    /// <param name="status">记录状态。</param>
     /// <param name="page">页码。</param>
     /// <param name="pageSize">每页条数。</param>
     /// <param name="ct">取消任务标记。</param>
     /// <returns>回合及下注信息列表。</returns>
     Task<ApiResult<List<RoundUserBetOutput>>> GetRecordsAsync(
         string address,
-        string status = "all",
+        BetRecordStatus status = BetRecordStatus.All,
         int page = 1,
         int pageSize = 10,
         CancellationToken ct = default);

--- a/TonPrediction.Infrastructure/Database/Repository/BetRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/BetRepository.cs
@@ -5,6 +5,7 @@ using SqlSugar;
 using TonPrediction.Application.Database.Config;
 using TonPrediction.Application.Database.Entities;
 using TonPrediction.Application.Database.Repository;
+using System.Linq.Expressions;
 
 namespace TonPrediction.Infrastructure.Database.Repository
 {
@@ -24,19 +25,15 @@ namespace TonPrediction.Infrastructure.Database.Repository
         /// <inheritdoc />
         public async Task<List<BetEntity>> GetPagedByAddressAsync(
             string address,
-            string status,
+            Expression<Func<BetEntity, bool>>? predicate,
             int page,
             int pageSize,
             CancellationToken ct = default)
         {
             var query = Db.Queryable<BetEntity>()
                 .Where(b => b.UserAddress == address);
-            query = status switch
-            {
-                "claimed" => query.Where(b => b.Claimed),
-                "unclaimed" => query.Where(b => !b.Claimed),
-                _ => query
-            };
+            if (predicate != null)
+                query = query.Where(predicate);
             return await query.OrderBy(b => b.Id, OrderByType.Desc)
                 .ToPageListAsync(page, pageSize);
         }


### PR DESCRIPTION
## Summary
- introduce `BetRecordStatus` enum
- use `BetRecordStatus` in prediction record API and service
- pass filter lambdas directly to `IBetRepository`

## Testing
- `dotnet format --verify-no-changes --verbosity diag`
- `dotnet build -c Release --no-restore`
- `dotnet test TonPrediction.sln -c Release --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_686f1de19b288323a4571bf741502c1e