### PR TITLE
Add wallet listener types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ TON 网络的中心化预测游戏后端，提供回合创建、下注结算与�
 | `ENV_RABBITMQ_USER` | RabbitMQ 用户名 |
 | `ENV_RABBITMQ_PASSWORD` | RabbitMQ 密码 |
 | `TreasuryFeeRate` | 领奖手续费比例 |
+| `WalletListenerType` | 钱包监听方式（Sse、Rest、WebSocket） |
 
 3. 运行 `docker compose up -d db redis ton-node price-oracle`。
 4. 执行 `dotnet run --project TonPrediction.Api`。

--- a/TonPrediction.Api/Services/WalletListeners/RestWalletListener.cs
+++ b/TonPrediction.Api/Services/WalletListeners/RestWalletListener.cs
@@ -1,0 +1,37 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using TonPrediction.Application.Services;
+using TonPrediction.Application.Services.Interface;
+
+namespace TonPrediction.Api.Services.WalletListeners;
+
+/// <summary>
+/// 通过轮询 REST API 的钱包监听实现。
+/// </summary>
+public class RestWalletListener(IHttpClientFactory httpFactory) : IWalletListener
+{
+    private readonly HttpClient _http = httpFactory.CreateClient("TonApi");
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TonTxDetail> ListenAsync(string walletAddress, ulong lastLt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var url = $"/v2/blockchain/accounts/{walletAddress}/transactions?limit=20&to_lt={lastLt}";
+            var resp = await _http.GetFromJsonAsync<AccountTxList>(url, ct);
+            if (resp?.Transactions != null)
+            {
+                foreach (var tx in resp.Transactions)
+                {
+                    if (tx.Lt > lastLt)
+                    {
+                        lastLt = tx.Lt;
+                        yield return tx with { Lt = tx.Lt };
+                    }
+                }
+            }
+            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+        }
+    }
+}

--- a/TonPrediction.Api/Services/WalletListeners/SseWalletListener.cs
+++ b/TonPrediction.Api/Services/WalletListeners/SseWalletListener.cs
@@ -1,0 +1,104 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
+using TonPrediction.Application.Services;
+using TonPrediction.Application.Services.Interface;
+
+namespace TonPrediction.Api.Services.WalletListeners;
+
+/// <summary>
+/// 基于 SSE 的钱包监听实现。
+/// </summary>
+public class SseWalletListener(IHttpClientFactory httpFactory, ILogger<SseWalletListener> logger) : IWalletListener
+{
+    private readonly HttpClient _http = httpFactory.CreateClient("TonApi");
+    private readonly ILogger<SseWalletListener> _logger = logger;
+    private const string SseUrlTemplate = "/v2/sse/accounts/transactions?accounts={0}";
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TonTxDetail> ListenAsync(string walletAddress, ulong lastLt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        if (lastLt > 0)
+        {
+            var history = await FetchMissedListAsync(walletAddress, lastLt, ct);
+            foreach (var tx in history)
+            {
+                yield return tx;
+                lastLt = tx.Lt;
+            }
+        }
+
+        var backoff = TimeSpan.FromSeconds(3);
+        while (!ct.IsCancellationRequested)
+        {
+            var items = new List<TonTxDetail>();
+            try
+            {
+                await using var stream = await _http.GetStreamAsync(string.Format(SseUrlTemplate, walletAddress), ct);
+                using var reader = new StreamReader(stream);
+                string? eventName = null;
+                while (!reader.EndOfStream && !ct.IsCancellationRequested)
+                {
+                    var line = await reader.ReadLineAsync(ct);
+                    if (string.IsNullOrEmpty(line)) continue;
+                    if (line.StartsWith("event:"))
+                    {
+                        eventName = line["event:".Length..].Trim();
+                        continue;
+                    }
+                    if (line.StartsWith("data:") && eventName == "message")
+                    {
+                        var json = line["data:".Length..].Trim();
+                        var head = JsonConvert.DeserializeObject<SseTxHead>(json)!;
+                        var detail = await _http.GetFromJsonAsync<TonTxDetail>($"/v2/blockchain/transactions/{head.Tx_Hash}", ct);
+                        if (detail != null)
+                        {
+                            items.Add(detail with { Hash = head.Tx_Hash, Lt = head.Lt });
+                            lastLt = head.Lt;
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                yield break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "SSE error");
+                items.AddRange(await FetchMissedListAsync(walletAddress, lastLt, ct));
+                await Task.Delay(backoff, ct);
+                backoff = TimeSpan.FromSeconds(Math.Min(backoff.TotalSeconds * 2, 30));
+            }
+
+            foreach (var tx in items)
+            {
+                yield return tx;
+            }
+        }
+    }
+
+    private async Task<List<TonTxDetail>> FetchMissedListAsync(string walletAddress, ulong lastLt, CancellationToken ct)
+    {
+        var list = new List<TonTxDetail>();
+        var url = $"/v2/blockchain/accounts/{walletAddress}/transactions?limit=20&to_lt={lastLt}";
+        try
+        {
+            var resp = await _http.GetFromJsonAsync<AccountTxList>(url, ct);
+            if (resp?.Transactions != null)
+            {
+                foreach (var tx in resp.Transactions)
+                {
+                    list.Add(tx with { Lt = tx.Lt });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "fetch history error");
+        }
+
+        return list;
+    }
+}

--- a/TonPrediction.Api/Services/WalletListeners/WalletListenerModels.cs
+++ b/TonPrediction.Api/Services/WalletListeners/WalletListenerModels.cs
@@ -1,0 +1,15 @@
+namespace TonPrediction.Api.Services.WalletListeners;
+
+/// <summary>
+/// TonAPI SSE "message" 事件载荷。
+/// </summary>
+/// <param name="Account_Id">账户标识。</param>
+/// <param name="Lt">账户逻辑时间。</param>
+/// <param name="Tx_Hash">交易哈希。</param>
+public record SseTxHead(string Account_Id, ulong Lt, string Tx_Hash);
+
+/// <summary>
+/// TonAPI 账户交易列表响应。
+/// </summary>
+/// <param name="Transactions">交易数组。</param>
+public record AccountTxList(TonPrediction.Application.Services.TonTxDetail[] Transactions);

--- a/TonPrediction.Api/Services/WalletListeners/WebSocketWalletListener.cs
+++ b/TonPrediction.Api/Services/WalletListeners/WebSocketWalletListener.cs
@@ -1,0 +1,62 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Newtonsoft.Json;
+using TonPrediction.Application.Services;
+using TonPrediction.Application.Services.Interface;
+
+namespace TonPrediction.Api.Services.WalletListeners;
+
+/// <summary>
+/// 通过 WebSocket 订阅交易的监听实现。
+/// </summary>
+public class WebSocketWalletListener(IHttpClientFactory httpFactory, ILogger<WebSocketWalletListener> logger) : IWalletListener
+{
+    private readonly HttpClient _http = httpFactory.CreateClient("TonApi");
+    private readonly ILogger<WebSocketWalletListener> _logger = logger;
+    private const string WsUrlTemplate = "/v2/ws/accounts/transactions?accounts={0}";
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<TonTxDetail> ListenAsync(string walletAddress, ulong lastLt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        var baseUri = _http.BaseAddress ?? new Uri("https://tonapi.io");
+        var wsUri = new Uri(baseUri, string.Format(WsUrlTemplate, walletAddress));
+        using var ws = new ClientWebSocket();
+        await ws.ConnectAsync(wsUri, ct);
+        var buffer = new byte[4096];
+        while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
+        {
+            var items = new List<TonTxDetail>();
+            var result = await ws.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                break;
+            }
+            var text = Encoding.UTF8.GetString(buffer, 0, result.Count);
+            try
+            {
+                var head = JsonConvert.DeserializeObject<SseTxHead>(text);
+                if (head != null)
+                {
+                    var detail = await _http.GetFromJsonAsync<TonTxDetail>($"/v2/blockchain/transactions/{head.Tx_Hash}", ct);
+                    if (detail != null)
+                    {
+                        items.Add(detail with { Hash = head.Tx_Hash, Lt = head.Lt });
+                        lastLt = head.Lt;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "WS parse error");
+            }
+
+            foreach (var tx in items)
+            {
+                yield return tx;
+            }
+        }
+    }
+}

--- a/TonPrediction.Api/appsettings.Development.json
+++ b/TonPrediction.Api/appsettings.Development.json
@@ -4,5 +4,6 @@
     "TonCenterEndPoint": "https://testnet.toncenter.com/api/v2/jsonRPC",
     "ApiKey": "AFYNAW47MI37SJIAAAACJCP4ZPHT2YBPWNUFXFO73P46FXUWUFUWU2UBOMEBE2VVWOCPGNY"
   },
-  "TreasuryFeeRate": "0.03"
+  "TreasuryFeeRate": "0.03",
+  "WalletListenerType": "Sse"
 }

--- a/TonPrediction.Api/appsettings.json
+++ b/TonPrediction.Api/appsettings.json
@@ -70,5 +70,6 @@
     "BaseUrl": "https://tonapi.io",
     "TonCenterEndPoint": "https://toncenter.com/api/v2/jsonRPC",
     "ApiKey": "d1f"
-  }
+  },
+  "WalletListenerType": "Sse"
 }

--- a/TonPrediction.Application/Config/WalletConfig.cs
+++ b/TonPrediction.Application/Config/WalletConfig.cs
@@ -20,5 +20,10 @@ namespace TonPrediction.Application.Config
         /// 主钱包私钥
         /// </summary>
         public string ENV_MASTER_WALLET_PK { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 钱包监听方式，默认为 Sse。
+        /// </summary>
+        public string ListenerType { get; set; } = "Sse";
     }
 }

--- a/TonPrediction.Application/Enums/WalletListenerType.cs
+++ b/TonPrediction.Application/Enums/WalletListenerType.cs
@@ -1,0 +1,22 @@
+namespace TonPrediction.Application.Enums;
+
+/// <summary>
+/// 钱包监听类型。
+/// </summary>
+public enum WalletListenerType
+{
+    /// <summary>
+    /// 使用 Server-Sent Events。
+    /// </summary>
+    Sse,
+
+    /// <summary>
+    /// 通过定期轮询 REST API。
+    /// </summary>
+    Rest,
+
+    /// <summary>
+    /// 通过 WebSocket 订阅。
+    /// </summary>
+    WebSocket
+}

--- a/TonPrediction.Application/Services/Interface/IWalletListener.cs
+++ b/TonPrediction.Application/Services/Interface/IWalletListener.cs
@@ -1,0 +1,18 @@
+using TonPrediction.Application.Services;
+
+namespace TonPrediction.Application.Services.Interface;
+
+/// <summary>
+/// 钱包事件监听接口。
+/// </summary>
+public interface IWalletListener
+{
+    /// <summary>
+    /// 开始监听指定钱包地址的新交易。
+    /// </summary>
+    /// <param name="walletAddress">钱包地址。</param>
+    /// <param name="lastLt">上次处理的逻辑时间。</param>
+    /// <param name="ct">取消令牌。</param>
+    /// <returns>交易异步枚举。</returns>
+    IAsyncEnumerable<TonTxDetail> ListenAsync(string walletAddress, ulong lastLt, CancellationToken ct);
+}

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -11,6 +11,7 @@ using TonPrediction.Application.Database.Repository;
 using TonPrediction.Application.Enums;
 using TonPrediction.Application.Config;
 using TonPrediction.Application.Services.Interface;
+using TonPrediction.Application.Services;
 using Xunit;
 
 namespace TonPrediction.Test;
@@ -74,8 +75,8 @@ public class TonEventListenerTests
             scopeFactory.Object,
             notifier.Object,
             NullLogger<TonEventListener>.Instance,
-            new Mock<IHttpClientFactory>().Object,
             Mock.Of<IDistributedLock>(),
+            Mock.Of<IWalletListener>(),
             walletConfig);
 
         var tx = new TonTxDetail(2m, new InMsg("sender", "1 bull", "addr"), "hash")
@@ -137,8 +138,8 @@ public class TonEventListenerTests
             scopeFactory.Object,
             notifier.Object,
             NullLogger<TonEventListener>.Instance,
-            new Mock<IHttpClientFactory>().Object,
             Mock.Of<IDistributedLock>(),
+            Mock.Of<IWalletListener>(),
             walletConfig);
 
         var tx = new TonTxDetail(1m, new InMsg("sender", "1 bull", "addr"), "hash") { Lt = 2 };


### PR DESCRIPTION
## Summary
- add wallet listener type enum and configuration
- add IWalletListener interface with REST and WebSocket implementations
- update TonEventListener to use pluggable wallet listener
- register implementations via configuration
- expose new setting in README

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68706ed18c348323a923935cac06ff15