### PR TITLE
Implement detailed Ton transaction model

### DIFF
--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -114,13 +114,13 @@ public class TonEventListener(IServiceScopeFactory scopeFactory, IPredictionHubS
     /// <param name="tx">交易详情。</param>
     internal virtual async Task ProcessTransactionAsync(TonTxDetail tx)
     {
-        var match = CommentRegex.Match(tx.In_Message?.Comment ?? string.Empty);
+        var match = CommentRegex.Match(tx.In_Msg?.Decoded_Body.Text ?? string.Empty);
         if (!match.Success || !long.TryParse(match.Groups[1].Value, out var roundId)) return;
         var side = match.Groups[2].Value.ToLowerInvariant();
         //var roundId = match.Groups[3].Value.ToLowerInvariant();
 
         var amount = tx.Amount;        // TonAPI 已返回普通 TON
-        var sender = tx.In_Message?.Source ?? string.Empty;
+        var sender = tx.In_Msg?.Source.Address ?? string.Empty;
         var position = side == "bull" ? Position.Bull : Position.Bear;
 
         using var scope = _scopeFactory.CreateScope();

--- a/TonPrediction.Api/Services/WalletListeners/RestWalletListener.cs
+++ b/TonPrediction.Api/Services/WalletListeners/RestWalletListener.cs
@@ -10,7 +10,7 @@ namespace TonPrediction.Api.Services.WalletListeners;
 /// <summary>
 /// 通过轮询 REST API 的钱包监听实现。
 /// </summary>
-public class RestWalletListener(ILogger<RestWalletListener> logger,IHttpClientFactory httpFactory) : IWalletListener
+public class RestWalletListener(ILogger<RestWalletListener> logger, IHttpClientFactory httpFactory) : IWalletListener
 {
     private readonly HttpClient _http = httpFactory.CreateClient("TonApi");
 

--- a/TonPrediction.Application/Services/BetService.cs
+++ b/TonPrediction.Application/Services/BetService.cs
@@ -38,12 +38,12 @@ public class BetService(
             api.SetRsult(ApiResultCode.ErrorParams, false);
             return api;
         }
-        if (!string.Equals(detail.In_Message?.Destination, _wallet, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(detail.In_Msg?.Destination.Address, _wallet, StringComparison.OrdinalIgnoreCase))
         {
             api.SetRsult(ApiResultCode.ErrorParams, false);
             return api;
         }
-        var match = CommentRegex.Match(detail.In_Message?.Comment ?? string.Empty);
+        var match = CommentRegex.Match(detail.In_Msg?.Decoded_Body.Text ?? string.Empty);
         if (!match.Success || !long.TryParse(match.Groups[1].Value, out var roundId))
         {
             api.SetRsult(ApiResultCode.ErrorParams, false);
@@ -65,7 +65,7 @@ public class BetService(
         var bet = new BetEntity
         {
             RoundId = round.Id,
-            UserAddress = detail.In_Message?.Source ?? string.Empty,
+            UserAddress = detail.In_Msg?.Source.Address ?? string.Empty,
             Amount = detail.Amount,
             Position = position,
             Claimed = false,
@@ -100,25 +100,3 @@ public class BetService(
         return api;
     }
 }
-
-/// <summary>
-/// TonAPI 交易详情模型。
-/// </summary>
-/// <param name="Amount"></param>
-/// <param name="In_Message"></param>
-/// <param name="Hash"></param>
-public record TonTxDetail(decimal Amount, InMsg? In_Message, string Hash)
-{
-    /// <summary>
-    /// 账户逻辑时间。
-    /// </summary>
-    public ulong Lt { get; init; }
-}
-
-/// <summary>
-/// 入站消息模型。
-/// </summary>
-/// <param name="Source"></param>
-/// <param name="Comment"></param>
-/// <param name="Destination"></param>
-public record InMsg(string? Source, string? Comment, string? Destination);

--- a/TonPrediction.Application/Services/TonTxDetail.cs
+++ b/TonPrediction.Application/Services/TonTxDetail.cs
@@ -1,0 +1,462 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace TonPrediction.Application.Services;
+
+/// <summary>
+/// TonAPI 交易详情模型。
+/// </summary>
+public record TonTxDetail
+{
+    /// <summary>
+    /// 交易哈希值。
+    /// </summary>
+    [JsonPropertyName("hash")]
+    public string Hash { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 账户逻辑时间。
+    /// </summary>
+    [JsonPropertyName("lt")]
+    public ulong Lt { get; set; }
+
+    /// <summary>
+    /// 交易存在的账户信息。
+    /// </summary>
+    [JsonPropertyName("account")]
+    public TxAccount Account { get; set; } = new();
+
+    /// <summary>
+    /// 交易是否执行成功。
+    /// </summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// Unix 时间戳。
+    /// </summary>
+    [JsonPropertyName("utime")]
+    public ulong Utime { get; set; }
+
+    /// <summary>
+    /// 初始状态。
+    /// </summary>
+    [JsonPropertyName("orig_status")]
+    public string Orig_Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 最终状态。
+    /// </summary>
+    [JsonPropertyName("end_status")]
+    public string End_Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 所有费用累计。
+    /// </summary>
+    [JsonPropertyName("total_fees")]
+    public ulong Total_Fees { get; set; }
+
+    /// <summary>
+    /// 交易结束时的账户余额。
+    /// </summary>
+    [JsonPropertyName("end_balance")]
+    public ulong End_Balance { get; set; }
+
+    /// <summary>
+    /// 交易类型。
+    /// </summary>
+    [JsonPropertyName("transaction_type")]
+    public string Transaction_Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 状态新值的支付样本。
+    /// </summary>
+    [JsonPropertyName("state_update_old")]
+    public string State_Update_Old { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 状态更新后的值。
+    /// </summary>
+    [JsonPropertyName("state_update_new")]
+    public string State_Update_New { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 入库消息。
+    /// </summary>
+    [JsonPropertyName("in_msg")]
+    public InMsg? In_Msg { get; set; }
+
+    /// <summary>
+    /// 出库消息列表。
+    /// </summary>
+    [JsonPropertyName("out_msgs")]
+    public OutMsg[] Out_Msgs { get; set; } = Array.Empty<OutMsg>();
+
+    /// <summary>
+    /// 所属块信息。
+    /// </summary>
+    [JsonPropertyName("block")]
+    public string Block { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 上一条交易的哈希。
+    /// </summary>
+    [JsonPropertyName("prev_trans_hash")]
+    public string Prev_Trans_Hash { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 上一条交易的 lt 值。
+    /// </summary>
+    [JsonPropertyName("prev_trans_lt")]
+    public ulong Prev_Trans_Lt { get; set; }
+
+    /// <summary>
+    /// 计算阶段详情。
+    /// </summary>
+    [JsonPropertyName("compute_phase")]
+    public ComputePhase Compute_Phase { get; set; } = new();
+
+    /// <summary>
+    /// 存储阶段详情。
+    /// </summary>
+    [JsonPropertyName("storage_phase")]
+    public StoragePhase Storage_Phase { get; set; } = new();
+
+    /// <summary>
+    /// 赋值阶段详情。
+    /// </summary>
+    [JsonPropertyName("credit_phase")]
+    public CreditPhase Credit_Phase { get; set; } = new();
+
+    /// <summary>
+    /// 操作阶段详情。
+    /// </summary>
+    [JsonPropertyName("action_phase")]
+    public ActionPhase Action_Phase { get; set; } = new();
+
+    /// <summary>
+    /// 是否中止。
+    /// </summary>
+    [JsonPropertyName("aborted")]
+    public bool Aborted { get; set; }
+
+    /// <summary>
+    /// 是否消逝。
+    /// </summary>
+    [JsonPropertyName("destroyed")]
+    public bool Destroyed { get; set; }
+
+    /// <summary>
+    /// 原始交易串。
+    /// </summary>
+    [JsonPropertyName("raw")]
+    public string Raw { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 返回的账户金额，为 In_Msg.Value 的方便展示。
+    /// </summary>
+    [JsonIgnore]
+    public decimal Amount => In_Msg?.Value ?? 0;
+}
+
+/// <summary>
+/// 交易账户信息。
+/// </summary>
+public class TxAccount
+{
+    /// <summary>
+    /// 钱包地址。
+    /// </summary>
+    [JsonPropertyName("address")]
+    public string Address { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 是否为骗子地址。
+    /// </summary>
+    [JsonPropertyName("is_scam")]
+    public bool Is_Scam { get; set; }
+
+    /// <summary>
+    /// 是否钱包地址。
+    /// </summary>
+    [JsonPropertyName("is_wallet")]
+    public bool Is_Wallet { get; set; }
+}
+
+/// <summary>
+/// 入库消息模型。
+/// </summary>
+public class InMsg
+{
+    /// <summary>
+    /// 消息类型。
+    /// </summary>
+    [JsonPropertyName("msg_type")]
+    public string Msg_Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 创建时的 lt。
+    /// </summary>
+    [JsonPropertyName("created_lt")]
+    public ulong Created_Lt { get; set; }
+
+    /// <summary>
+    /// 是否禁用 Ihr。
+    /// </summary>
+    [JsonPropertyName("ihr_disabled")]
+    public bool Ihr_Disabled { get; set; }
+
+    /// <summary>
+    /// 是否可点操作。
+    /// </summary>
+    [JsonPropertyName("bounce")]
+    public bool Bounce { get; set; }
+
+    /// <summary>
+    /// 是否已被跳返。
+    /// </summary>
+    [JsonPropertyName("bounced")]
+    public bool Bounced { get; set; }
+
+    /// <summary>
+    /// 金额值（nano TON）。
+    /// </summary>
+    [JsonPropertyName("value")]
+    public decimal Value { get; set; }
+
+    /// <summary>
+    /// 转运费用。
+    /// </summary>
+    [JsonPropertyName("fwd_fee")]
+    public ulong Fwd_Fee { get; set; }
+
+    /// <summary>
+    /// Ihr 费用。
+    /// </summary>
+    [JsonPropertyName("ihr_fee")]
+    public ulong Ihr_Fee { get; set; }
+
+    /// <summary>
+    /// 目标地址。
+    /// </summary>
+    [JsonPropertyName("destination")]
+    public AddressInfo Destination { get; set; } = new();
+
+    /// <summary>
+    /// 发送地址。
+    /// </summary>
+    [JsonPropertyName("source")]
+    public AddressInfo Source { get; set; } = new();
+
+    /// <summary>
+    /// 导入费用。
+    /// </summary>
+    [JsonPropertyName("import_fee")]
+    public ulong Import_Fee { get; set; }
+
+    /// <summary>
+    /// 创建时间。
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public ulong Created_At { get; set; }
+
+    /// <summary>
+    /// 操作码。
+    /// </summary>
+    [JsonPropertyName("op_code")]
+    public string Op_Code { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 消息哈希值。
+    /// </summary>
+    [JsonPropertyName("hash")]
+    public string Hash { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 原始运动文本。
+    /// </summary>
+    [JsonPropertyName("raw_body")]
+    public string Raw_Body { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 解码操作名称。
+    /// </summary>
+    [JsonPropertyName("decoded_op_name")]
+    public string Decoded_Op_Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 解码后的体内容。
+    /// </summary>
+    [JsonPropertyName("decoded_body")]
+    public DecodedBody Decoded_Body { get; set; } = new();
+}
+
+/// <summary>
+/// 账户地址信息。
+/// </summary>
+public class AddressInfo
+{
+    /// <summary>
+    /// 地址值。
+    /// </summary>
+    [JsonPropertyName("address")]
+    public string Address { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 是否是骗子地址。
+    /// </summary>
+    [JsonPropertyName("is_scam")]
+    public bool Is_Scam { get; set; }
+
+    /// <summary>
+    /// 是否钱包地址。
+    /// </summary>
+    [JsonPropertyName("is_wallet")]
+    public bool Is_Wallet { get; set; }
+}
+
+/// <summary>
+/// 解码体内容。
+/// </summary>
+public class DecodedBody
+{
+    /// <summary>
+    /// 解码文本。
+    /// </summary>
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// 交易输出消息。
+/// </summary>
+public class OutMsg
+{
+    // 当前不需要详细字段，保留空的实体
+}
+
+/// <summary>
+/// 计算阶段。
+/// </summary>
+public class ComputePhase
+{
+    /// <summary>
+    /// 是否被跳过。
+    /// </summary>
+    [JsonPropertyName("skipped")]
+    public bool Skipped { get; set; }
+
+    /// <summary>
+    /// VM 是否执行成功。
+    /// </summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// 消耗的 gas 费用。
+    /// </summary>
+    [JsonPropertyName("gas_fees")]
+    public ulong Gas_Fees { get; set; }
+
+    /// <summary>
+    /// 使用的 gas 量。
+    /// </summary>
+    [JsonPropertyName("gas_used")]
+    public ulong Gas_Used { get; set; }
+
+    /// <summary>
+    /// VM 走步数。
+    /// </summary>
+    [JsonPropertyName("vm_steps")]
+    public ulong Vm_Steps { get; set; }
+
+    /// <summary>
+    /// 退出码。
+    /// </summary>
+    [JsonPropertyName("exit_code")]
+    public int Exit_Code { get; set; }
+
+    /// <summary>
+    /// 退出描述。
+    /// </summary>
+    [JsonPropertyName("exit_code_description")]
+    public string Exit_Code_Description { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// 存储阶段信息。
+/// </summary>
+public class StoragePhase
+{
+    /// <summary>
+    /// 收取的费用。
+    /// </summary>
+    [JsonPropertyName("fees_collected")]
+    public ulong Fees_Collected { get; set; }
+
+    /// <summary>
+    /// 状态改变类型。
+    /// </summary>
+    [JsonPropertyName("status_change")]
+    public string Status_Change { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// 赋值阶段信息。
+/// </summary>
+public class CreditPhase
+{
+    /// <summary>
+    /// 收取费用。
+    /// </summary>
+    [JsonPropertyName("fees_collected")]
+    public ulong Fees_Collected { get; set; }
+
+    /// <summary>
+    /// 赋上的金额。
+    /// </summary>
+    [JsonPropertyName("credit")]
+    public decimal Credit { get; set; }
+}
+
+/// <summary>
+/// 行动阶段信息。
+/// </summary>
+public class ActionPhase
+{
+    /// <summary>
+    /// 是否成功。
+    /// </summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// 结果码。
+    /// </summary>
+    [JsonPropertyName("result_code")]
+    public int Result_Code { get; set; }
+
+    /// <summary>
+    /// 总作用数量。
+    /// </summary>
+    [JsonPropertyName("total_actions")]
+    public int Total_Actions { get; set; }
+
+    /// <summary>
+    /// 被跳过的作用数。
+    /// </summary>
+    [JsonPropertyName("skipped_actions")]
+    public int Skipped_Actions { get; set; }
+
+    /// <summary>
+    /// 转运费用。
+    /// </summary>
+    [JsonPropertyName("fwd_fees")]
+    public ulong Fwd_Fees { get; set; }
+
+    /// <summary>
+    /// 总费用。
+    /// </summary>
+    [JsonPropertyName("total_fees")]
+    public ulong Total_Fees { get; set; }
+}

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -79,9 +79,17 @@ public class TonEventListenerTests
             Mock.Of<IWalletListener>(),
             walletConfig);
 
-        var tx = new TonTxDetail(2m, new InMsg("sender", "1 bull", "addr"), "hash")
+        var tx = new TonTxDetail
         {
-            Lt = 1
+            Hash = "hash",
+            Lt = 1,
+            In_Msg = new InMsg
+            {
+                Source = new AddressInfo { Address = "sender" },
+                Destination = new AddressInfo { Address = "addr" },
+                Value = 2m,
+                Decoded_Body = new DecodedBody { Text = "1 bull" }
+            }
         };
         await listener.ProcessTransactionAsync(tx);
 
@@ -142,7 +150,18 @@ public class TonEventListenerTests
             Mock.Of<IWalletListener>(),
             walletConfig);
 
-        var tx = new TonTxDetail(1m, new InMsg("sender", "1 bull", "addr"), "hash") { Lt = 2 };
+        var tx = new TonTxDetail
+        {
+            Hash = "hash",
+            Lt = 2,
+            In_Msg = new InMsg
+            {
+                Source = new AddressInfo { Address = "sender" },
+                Destination = new AddressInfo { Address = "addr" },
+                Value = 1m,
+                Decoded_Body = new DecodedBody { Text = "1 bull" }
+            }
+        };
         await listener.ProcessTransactionAsync(tx);
 
         betRepo.Verify(b => b.UpdateByPrimaryKeyAsync(bet), Times.Once);


### PR DESCRIPTION
## Summary
- add full `TonTxDetail` model for TonAPI
- adjust betting and event listener logic for new transaction schema
- update Rest listener spacing and unit tests for new model

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6870ad8adfd88323859b4b162e2bbcc3