### PR TITLE
Deduplicate bet comment regex

### DIFF
--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -5,6 +5,7 @@ using TonPrediction.Application.Output;
 using TonPrediction.Application.Services.Interface;
 using TonPrediction.Application.Cache;
 using System.Text.RegularExpressions;
+using TonPrediction.Application.Common;
 using TonPrediction.Application.Config;
 using TonPrediction.Application.Services;
 using TonPrediction.Api.Services.WalletListeners;
@@ -54,9 +55,10 @@ public class TonEventListener(IServiceScopeFactory scopeFactory, IPredictionHubS
     private ulong _lastLt;
 
     /// <summary>
-    /// 评论正则表达式，用于解析交易备注中的事件信息。
+    /// <summary>
+    /// Bet 事件备注解析正则。
     /// </summary>
-    private static readonly Regex CommentRegex = new(@"^\s*(?<evt>\w+)\s+(?<rid>\d+)\s+(?<dir>bull|bear)\s*$", RegexOptions.IgnoreCase);
+    private static readonly Regex CommentRegex = CommentRegexCollection.Bet;
 
     /// <summary>
     /// 执行
@@ -121,7 +123,7 @@ public class TonEventListener(IServiceScopeFactory scopeFactory, IPredictionHubS
         var text = tx.In_Msg?.Decoded_Body.Text;
         if (string.IsNullOrEmpty(text)) return;
         var match = CommentRegex.Match(text);
-        if (!match.Success|| !match.Groups["evt"].Value.Equals("Bet", StringComparison.OrdinalIgnoreCase)) return;
+        if (!match.Success || !match.Groups["evt"].Value.Equals("Bet", StringComparison.OrdinalIgnoreCase)) return;
 
         // 解析事件名称、回合 ID 和下注方向
         //string eventName = match.Groups["evt"].Value;

--- a/TonPrediction.Application/Common/CommentRegexCollection.cs
+++ b/TonPrediction.Application/Common/CommentRegexCollection.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+
+namespace TonPrediction.Application.Common;
+
+/// <summary>
+/// 交易备注解析正则表达式集合。
+/// </summary>
+public static class CommentRegexCollection
+{
+    /// <summary>
+    /// Bet 事件备注解析正则。
+    /// 解析格式："Bet 1 bull"。
+    /// </summary>
+    public static readonly Regex Bet = new(
+        @"^\s*(?<evt>\w+)\s+(?<rid>\d+)\s+(?<dir>bull|bear)\s*$",
+        RegexOptions.IgnoreCase);
+}

--- a/TonPrediction.Application/Services/BetService.cs
+++ b/TonPrediction.Application/Services/BetService.cs
@@ -6,6 +6,7 @@ using TonPrediction.Application.Database.Entities;
 using TonPrediction.Application.Database.Repository;
 using TonPrediction.Application.Enums;
 using TonPrediction.Application.Services.Interface;
+using TonPrediction.Application.Common;
 
 namespace TonPrediction.Application.Services;
 
@@ -24,9 +25,9 @@ public class BetService(
     private readonly IRoundRepository _roundRepo = roundRepo;
 
     /// <summary>
-    /// 评论正则表达式，用于解析交易备注中的事件信息。
+    /// Bet 事件备注解析正则。
     /// </summary>
-    private static readonly Regex CommentRegex = new(@"^\s*(?<evt>\w+)\s+(?<rid>\d+)\s+(?<dir>bull|bear)\s*$", RegexOptions.IgnoreCase);
+    private static readonly Regex CommentRegex = CommentRegexCollection.Bet;
 
     /// <summary>
     /// 验证并上报用户下注信息
@@ -49,7 +50,7 @@ public class BetService(
         }
 
         var text = detail.In_Msg?.Decoded_Body.Text;
-        if (string.IsNullOrEmpty(text)) 
+        if (string.IsNullOrEmpty(text))
         {
             api.SetRsult(ApiResultCode.ErrorParams, false);
             return api;
@@ -58,7 +59,7 @@ public class BetService(
         var match = CommentRegex.Match(text);
 
         // 解析事件名称、回合 ID 和下注方向
-        if (!match.Success || !match.Groups["evt"].Value.Equals("Bet",StringComparison.OrdinalIgnoreCase))
+        if (!match.Success || !match.Groups["evt"].Value.Equals("Bet", StringComparison.OrdinalIgnoreCase))
         {
             api.SetRsult(ApiResultCode.ErrorParams, false);
             return api;

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -88,7 +88,7 @@ public class TonEventListenerTests
                 Source = new AddressInfo { Address = "sender" },
                 Destination = new AddressInfo { Address = "addr" },
                 Value = 2m,
-                Decoded_Body = new DecodedBody { Text = "1 bull" }
+                Decoded_Body = new DecodedBody { Text = "Bet 1 bull" }
             }
         };
         await listener.ProcessTransactionAsync(tx);
@@ -159,7 +159,7 @@ public class TonEventListenerTests
                 Source = new AddressInfo { Address = "sender" },
                 Destination = new AddressInfo { Address = "addr" },
                 Value = 1m,
-                Decoded_Body = new DecodedBody { Text = "1 bull" }
+                Decoded_Body = new DecodedBody { Text = "Bet 1 bull" }
             }
         };
         await listener.ProcessTransactionAsync(tx);


### PR DESCRIPTION
## Summary
- centralize `Bet` comment regex in `CommentRegexCollection`
- reuse new regex in `BetService` and `TonEventListener`
- fix tests to match new pattern

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6870bb9070188323a30f287df01cb02b