### PR TITLE
Add betPlaced SignalR event

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -43,6 +43,8 @@
 >hub.on("roundEnded", data => { /* ... */ });
 >
 >await hub.start();
+>// 用户在连接钱包后调用，确保能收到个人通知
+>await hub.invoke("joinAddress", userAddress);
 > ```
 >
 >**说明**：除 `currentRound` 与 `nextRound` 外，其他回合相关响应均同时包含 `id` 与 `epoch` 字段，`id` 用于后续业务请求，`epoch` 用于展示回合期次。
@@ -418,3 +420,17 @@ GET /api/predictions/pnl
 | `reward` | string(decimal) | 奖励金额 |
 | `claimed` | bool | 是否已领取 |
 
+## 1️⃣6️⃣ 下注成功通知（`betPlaced` • 单用户推送）
+
+- **SignalR 事件**：`betPlaced`
+- **触发时机**：监听到用户向主钱包转账并确认成功
+- **推送内容**：
+
+| 字段名 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | int | 回合唯一编号 |
+| `epoch` | int | 期次（Epoch） |
+| `amount` | string(decimal) | 下注金额 |
+| `txHash` | string | 交易哈希 |
+
+> 客户端连接 SignalR 后，需要在用户连接钱包时调用 `joinAddress` 方法并传入地址，服务器将基于该地址推送消息。

--- a/TonPrediction.Api/Hubs/PredictionHub.cs
+++ b/TonPrediction.Api/Hubs/PredictionHub.cs
@@ -7,6 +7,22 @@ namespace TonPrediction.Api.Hubs
     /// </summary>
     public class PredictionHub : Hub
     {
+        /// <summary>
+        /// 连接时不加入任何用户组。
+        /// </summary>
+        /// <returns>异步任务。</returns>
+        public override Task OnConnectedAsync() => base.OnConnectedAsync();
 
+        /// <summary>
+        /// 用户连接钱包后调用，加入对应地址组。
+        /// </summary>
+        /// <param name="address">钱包地址。</param>
+        public async Task JoinAddressAsync(string address)
+        {
+            if (string.IsNullOrWhiteSpace(address)) return;
+            await Groups.AddToGroupAsync(Context.ConnectionId, address);
+        }
+
+        // 断开连接时无需特殊处理，组成员会自动清理
     }
 }

--- a/TonPrediction.Api/Services/PredictionHubService.cs
+++ b/TonPrediction.Api/Services/PredictionHubService.cs
@@ -67,6 +67,27 @@ public class PredictionHubService(ILogger<PredictionHubService> logger, IHubCont
     }
 
     /// <summary>
+    /// 下注成功推送给指定地址。
+    /// </summary>
+    /// <param name="address">钱包地址。</param>
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
+    /// <param name="amount">下注金额。</param>
+    /// <param name="txHash">交易哈希。</param>
+    public Task PushBetPlacedAsync(string address, long roundId, long epoch, long amount, string txHash)
+    {
+        var output = new BetPlacedOutput
+        {
+            RoundId = roundId,
+            Epoch = epoch,
+            Amount = amount.ToAmountString(),
+            TxHash = txHash
+        };
+        logger.LogInformation("PushBetPlacedAsync.下注成功推送:{output}", JsonConvert.SerializeObject(output));
+        return _hub.Clients.Group(address).SendAsync("betPlaced", output);
+    }
+
+    /// <summary>
     /// 回合开始
     /// </summary>
     /// <param name="roundId">回合唯一编号。</param>

--- a/TonPrediction.Api/Services/TonEventListener.cs
+++ b/TonPrediction.Api/Services/TonEventListener.cs
@@ -183,5 +183,6 @@ public class TonEventListener(IServiceScopeFactory scopeFactory, IPredictionHubS
 
         var currentPrice = round.ClosePrice > 0 ? round.ClosePrice : round.LockPrice;
         await _notifier.PushNextRoundAsync(round, currentPrice);
+        await _notifier.PushBetPlacedAsync(sender, round.Id, round.Epoch, amount, tx.Hash);
     }
 }

--- a/TonPrediction.Application/Output/BetPlacedOutput.cs
+++ b/TonPrediction.Application/Output/BetPlacedOutput.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace TonPrediction.Application.Output;
+
+/// <summary>
+/// 下注成功推送内容。
+/// </summary>
+public class BetPlacedOutput
+{
+    /// <summary>
+    /// 回合唯一编号，用于业务请求。
+    /// </summary>
+    [JsonPropertyName("id")]
+    public long RoundId { get; set; }
+
+    /// <summary>
+    /// 回合期次。
+    /// </summary>
+    public long Epoch { get; set; }
+
+    /// <summary>
+    /// 下注金额。
+    /// </summary>
+    public string Amount { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 下注交易哈希。
+    /// </summary>
+    public string TxHash { get; set; } = string.Empty;
+}

--- a/TonPrediction.Application/Services/Interface/IPredictionHubService.cs
+++ b/TonPrediction.Application/Services/Interface/IPredictionHubService.cs
@@ -26,6 +26,16 @@ public interface IPredictionHubService : ITransientDependency
     Task PushNextRoundAsync(RoundEntity round, decimal currentPrice);
 
     /// <summary>
+    /// 推送下注成功消息至指定地址。
+    /// </summary>
+    /// <param name="address">钱包地址。</param>
+    /// <param name="roundId">回合唯一编号。</param>
+    /// <param name="epoch">回合期次。</param>
+    /// <param name="amount">下注金额。</param>
+    /// <param name="txHash">交易哈希。</param>
+    Task PushBetPlacedAsync(string address, long roundId, long epoch, long amount, string txHash);
+
+    /// <summary>
     /// 推送回合开始消息。
     /// </summary>
     /// <param name="roundId">回合唯一编号。</param>

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -56,6 +56,14 @@ public class TonEventListenerTests
                 It.IsAny<decimal>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
+        notifier.Setup(n => n.PushBetPlacedAsync(
+                "sender",
+                round.Id,
+                round.Epoch,
+                2,
+                "hash"))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
 
         var stateRepo = new Mock<IStateRepository>();
         var sp = new ServiceCollection()
@@ -127,6 +135,14 @@ public class TonEventListenerTests
             .ReturnsAsync(round);
 
         var notifier = new Mock<IPredictionHubService>();
+        notifier.Setup(n => n.PushBetPlacedAsync(
+                "sender",
+                round.Id,
+                round.Epoch,
+                1,
+                "hash"))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
 
         var stateRepo = new Mock<IStateRepository>();
         var sp = new ServiceCollection()


### PR DESCRIPTION
## Summary
- add `BetPlacedOutput` DTO
- join/disconnect SignalR groups based on wallet address
- push betPlaced notifications to specific address
- expose new `PushBetPlacedAsync` on hub service
- send betPlaced event when wallet transaction confirmed
- update API docs
- update unit tests

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6870e465604c8323b304944b048f692e