### PR TITLE
Centralize Ton API routing

### DIFF
--- a/TonPrediction.Application/Common/TonApiRoutes.cs
+++ b/TonPrediction.Application/Common/TonApiRoutes.cs
@@ -1,0 +1,27 @@
+namespace TonPrediction.Application.Common;
+
+/// <summary>
+/// Ton API 路由字符串集合。
+/// </summary>
+public static class TonApiRoutes
+{
+    /// <summary>
+    /// 获取指定钱包交易列表。
+    /// </summary>
+    public const string AccountTransactions = "/v2/blockchain/accounts/{0}/transactions?limit={1}&to_lt={2}";
+
+    /// <summary>
+    /// SSE 监听钱包交易。
+    /// </summary>
+    public const string SseAccountTransactions = "/v2/sse/accounts/transactions?accounts={0}";
+
+    /// <summary>
+    /// 获取消息交易列表。
+    /// </summary>
+    public const string MessageTransactions = "/v2/blockchain/messages/{0}/transactions";
+
+    /// <summary>
+    /// 获取交易详情。
+    /// </summary>
+    public const string TransactionDetail = "/v2/blockchain/transactions/{0}";
+}

--- a/TonPrediction.Application/Services/BetService.cs
+++ b/TonPrediction.Application/Services/BetService.cs
@@ -142,7 +142,7 @@ public class BetService(
     /// <returns></returns>
     public async Task<(string txHash, ulong lt)> WaitTxAsync(string msgHash)
     {
-        var url = $"/v2/blockchain/messages/{msgHash}/transactions";
+        var url = string.Format(TonApiRoutes.MessageTransactions, msgHash);
 
         while (true)
         {
@@ -163,7 +163,7 @@ public class BetService(
     /// <returns></returns>
     public async Task<TonTxDetail?> FetchDetailAsync(string txHash)
     {
-        return await _http.GetFromJsonAsync<TonTxDetail>($"/v2/blockchain/transactions/{txHash}");
+        return await _http.GetFromJsonAsync<TonTxDetail>(string.Format(TonApiRoutes.TransactionDetail, txHash));
     }
 
 

--- a/TonPrediction.Application/Services/WalletListeners/RestWalletListener.cs
+++ b/TonPrediction.Application/Services/WalletListeners/RestWalletListener.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using TonPrediction.Application.Services;
 using TonPrediction.Application.Services.Interface;
+using TonPrediction.Application.Common;
 
 namespace TonPrediction.Application.Services.WalletListeners;
 
@@ -20,7 +21,7 @@ public class RestWalletListener(ILogger<RestWalletListener> logger, IHttpClientF
     {
         while (!ct.IsCancellationRequested)
         {
-            var url = $"/v2/blockchain/accounts/{walletAddress}/transactions?limit=20&to_lt={lastLt}";
+            var url = string.Format(TonApiRoutes.AccountTransactions, walletAddress, 20, lastLt);
             var resp = await _http.GetAsync(url, ct);
 
             var content = await resp.Content.ReadAsStringAsync(ct);

--- a/TonPrediction.Application/Services/WalletListeners/WebSocketWalletListener.cs
+++ b/TonPrediction.Application/Services/WalletListeners/WebSocketWalletListener.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Linq;
 using TonPrediction.Application.Config;
 using TonPrediction.Application.Services;
 using TonPrediction.Application.Services.Interface;
+using TonPrediction.Application.Common;
 
 namespace TonPrediction.Application.Services.WalletListeners;
 
@@ -78,7 +79,7 @@ public class WebSocketWalletListener(IHttpClientFactory httpFactory, ILogger<Web
                 var head = token.ToObject<SseTxHead>();
                 if (head != null)
                 {
-                    var detail = await _http.GetFromJsonAsync<TonTxDetail>($"/v2/blockchain/transactions/{head.Tx_Hash}", ct);
+                    var detail = await _http.GetFromJsonAsync<TonTxDetail>(string.Format(TonApiRoutes.TransactionDetail, head.Tx_Hash), ct);
                     if (detail != null)
                     {
                         items.Add(detail with { Hash = head.Tx_Hash, Lt = head.Lt });


### PR DESCRIPTION
## Summary
- create `TonApiRoutes` for Ton API URL templates
- update services to reuse `TonApiRoutes`

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_6874adfacf708323bd321f5345a4a619