### PR TITLE
Add tolerance for bet lock time

### DIFF
--- a/TonPrediction.Api/Hubs/PredictionHub.cs
+++ b/TonPrediction.Api/Hubs/PredictionHub.cs
@@ -32,7 +32,7 @@ namespace TonPrediction.Api.Hubs
         public async Task JoinAddressAsync(string address)
         {
             if (string.IsNullOrWhiteSpace(address)) return;
-       
+
 
             await Groups.AddToGroupAsync(Context.ConnectionId, address.ToRawAddress());
 

--- a/TonPrediction.Test/BetServiceTests.cs
+++ b/TonPrediction.Test/BetServiceTests.cs
@@ -35,7 +35,7 @@ public class BetServiceTests
             roundRepo.Object,
             Mock.Of<IPredictionHubService>());
 
-        var result = await service.VerifyAsync(1);
+        var result = await service.VerifyAsync(1, "user");
 
         Assert.True(result.Data);
     }

--- a/TonPrediction.Test/TonEventListenerTests.cs
+++ b/TonPrediction.Test/TonEventListenerTests.cs
@@ -24,14 +24,16 @@ public class TonEventListenerTests
     [Fact]
     public async Task ProcessTransactionAsync_InsertsBetAndUpdatesRound()
     {
+        var lockTime = DateTime.UtcNow;
         var round = new RoundEntity
         {
             Symbol = "ton",
             Id = 1,
             Epoch = 1,
             CloseTime = DateTime.UtcNow.AddMinutes(5),
+            LockTime = lockTime,
             LockPrice = 1m,
-            Status = RoundStatus.Betting
+            Status = RoundStatus.Locked
         };
 
         BetEntity? inserted = null;
@@ -91,6 +93,7 @@ public class TonEventListenerTests
         {
             Hash = "hash",
             Lt = 1,
+            Utime = (ulong)new DateTimeOffset(lockTime).ToUnixTimeSeconds(),
             In_Msg = new InMsg
             {
                 Source = new AddressInfo { Address = "sender" },
@@ -114,14 +117,16 @@ public class TonEventListenerTests
     [Fact]
     public async Task ProcessTransactionAsync_UpdatesExistingBet()
     {
+        var lockTime2 = DateTime.UtcNow;
         var round = new RoundEntity
         {
             Symbol = "ton",
             Id = 1,
             Epoch = 1,
             CloseTime = DateTime.UtcNow.AddMinutes(5),
+            LockTime = lockTime2,
             LockPrice = 1m,
-            Status = RoundStatus.Betting
+            Status = RoundStatus.Locked
         };
 
         var bet = new BetEntity { TxHash = "hash", Lt = 0, Status = BetStatus.Pending };
@@ -170,6 +175,7 @@ public class TonEventListenerTests
         {
             Hash = "hash",
             Lt = 2,
+            Utime = (ulong)new DateTimeOffset(lockTime2).ToUnixTimeSeconds(),
             In_Msg = new InMsg
             {
                 Source = new AddressInfo { Address = "sender" },


### PR DESCRIPTION
## Summary
- add BetTimeToleranceSeconds to `TonEventListener` and check incoming bet time
- add same tolerance logic to `BetService.ReportAsync`
- update unit tests for `TonEventListener` and `BetService`
- run `dotnet format`, `dotnet build`, and `dotnet test`

## Testing
- `dotnet format`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build --blame-hang-timeout 5s`

------
https://chatgpt.com/codex/tasks/task_e_6875c8e79a488323992e70544ad8f218