### PR TITLE
Add WinnerSide field to recent API output

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -321,6 +321,7 @@ GET /api/predictions/round
 | `status` | enum | 回合状态 |
 | `bullOdds` | string(decimal) | 上涨赔率 |
 | `bearOdds` | string(decimal) | 下跌赔率 |
+| `winnerSide` | enum | 回合结果，获胜方 |
 | `position` | enum | 用户下注方向，可能为 null |
 | `betAmount` | string(decimal) | 用户下注金额 |
 | `reward` | string(decimal) | 奖励金额 |

--- a/TonPrediction.Application/Output/RoundUserBetOutput.cs
+++ b/TonPrediction.Application/Output/RoundUserBetOutput.cs
@@ -77,6 +77,11 @@ public class RoundUserBetOutput
     public string BearOdds { get; set; } = string.Empty;
 
     /// <summary>
+    /// 回合结果，指出看涨或看跌获胜。
+    /// </summary>
+    public Position? WinnerSide { get; set; }
+
+    /// <summary>
     /// 用户下注方向，若未下注则为 null。
     /// </summary>
     public Position? Position { get; set; }

--- a/TonPrediction.Application/Services/PredictionService.cs
+++ b/TonPrediction.Application/Services/PredictionService.cs
@@ -78,6 +78,7 @@ public class PredictionService(
                 Status = round.Status,
                 BullOdds = round.BullAmount > 0 ? ((decimal)round.TotalAmount / round.BullAmount).ToAmountString() : "0",
                 BearOdds = round.BearAmount > 0 ? ((decimal)round.TotalAmount / round.BearAmount).ToAmountString() : "0",
+                WinnerSide = round.WinnerSide,
                 Position = bet.Position,
                 BetAmount = bet.Amount.ToAmountString(),
                 Reward = bet.Reward.ToAmountString(),

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -131,6 +131,7 @@ public class RoundService(
                 Status = r.Status,
                 BullOdds = r.BullAmount > 0 ? ((decimal)r.TotalAmount / r.BullAmount).ToAmountString() : "0",
                 BearOdds = r.BearAmount > 0 ? ((decimal)r.TotalAmount / r.BearAmount).ToAmountString() : "0",
+                WinnerSide = r.WinnerSide,
                 Position = bet?.Position,
                 BetAmount = bet?.Amount.ToAmountString() ?? "0",
                 Reward = bet?.Reward.ToAmountString() ?? "0",

--- a/TonPrediction.Test/RoundServiceTests.cs
+++ b/TonPrediction.Test/RoundServiceTests.cs
@@ -32,7 +32,8 @@ public class RoundServiceTests
                 BullAmount = 60000000000,
                 BearAmount = 40000000000,
                 RewardAmount = 95000000000,
-                Status = RoundStatus.Completed
+                Status = RoundStatus.Completed,
+                WinnerSide = Position.Bull
             },
             new()
             {
@@ -75,6 +76,7 @@ public class RoundServiceTests
         Assert.Equal(2, result.Data.Count);
         Assert.Equal("10", result.Data[0].BetAmount);
         Assert.Equal(RoundStatus.Completed, result.Data[0].Status);
+        Assert.Equal(Position.Bull, result.Data[0].WinnerSide);
         Assert.Equal(RoundStatus.Locked, result.Data[1].Status);
     }
 


### PR DESCRIPTION
## Summary
- expose WinnerSide on `RoundUserBetOutput`
- map WinnerSide in round and prediction services
- update recent round tests
- document WinnerSide field in API spec

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build` *(failed: no output)*

------
https://chatgpt.com/codex/tasks/task_e_687704f34de483239647d38b11a08ddd