### PR TITLE
Fix refund record handling

### DIFF
--- a/TonPrediction.Api/Services/RoundScheduler.cs
+++ b/TonPrediction.Api/Services/RoundScheduler.cs
@@ -164,7 +164,7 @@ namespace TonPrediction.Api.Services
                 //计算奖励并更新下注记录
                 var bets = await betRepo.GetByRoundAsync(locked.Id, token);
                 var wallet = scope.ServiceProvider.GetRequiredService<IWalletService>();
-                var claimRepo = scope.ServiceProvider.GetRequiredService<IClaimRepository>();
+                var txRepo = scope.ServiceProvider.GetRequiredService<ITransactionRepository>();
                 var winTotal = winner switch
                 {
                     Position.Bull => locked.BullAmount,
@@ -187,12 +187,12 @@ namespace TonPrediction.Api.Services
 
                     if (winner == Position.Tie)
                     {
-                        var result = await wallet.TransferAsync(bet.UserAddress, reward, $"Refund {locked.Epoch}");
-                        await claimRepo.InsertAsync(new ClaimEntity
+                        var result = await wallet.TransferAsync(bet.UserAddress, bet.Amount, $"Refund {locked.Epoch}");
+                        await txRepo.InsertAsync(new TransactionEntity
                         {
-                            RoundId = locked.Id,
+                            BetId = bet.Id,
                             UserAddress = bet.UserAddress,
-                            Reward = reward,
+                            Amount = bet.Amount,
                             TxHash = result.TxHash,
                             Status = result.Status,
                             Lt = result.Lt,

--- a/TonPrediction.Application/Database/Entities/TransactionEntity.cs
+++ b/TonPrediction.Application/Database/Entities/TransactionEntity.cs
@@ -4,10 +4,10 @@ using TonPrediction.Application.Enums;
 namespace TonPrediction.Application.Database.Entities
 {
     /// <summary>
-    /// 用户领取奖励记录。
+    /// 领奖与退款交易记录。
     /// </summary>
-    [SugarTable("claim")]
-    public class ClaimEntity
+    [SugarTable("transaction")]
+    public class TransactionEntity
     {
         /// <summary>
         /// 主键编号。
@@ -16,10 +16,10 @@ namespace TonPrediction.Application.Database.Entities
         public int Id { get; set; }
 
         /// <summary>
-        /// 回合编号。
+        /// 下注记录编号。
         /// </summary>
-        [SugarColumn(ColumnName = "round_id")]
-        public long RoundId { get; set; }
+        [SugarColumn(ColumnName = "bet_id")]
+        public int BetId { get; set; }
 
         /// <summary>
         /// 用户地址。
@@ -28,10 +28,10 @@ namespace TonPrediction.Application.Database.Entities
         public string UserAddress { get; set; } = string.Empty;
 
         /// <summary>
-        /// 奖励金额。
+        /// 交易金额。
         /// </summary>
-        [SugarColumn(ColumnName = "reward", ColumnDataType = "bigint")]
-        public long Reward { get; set; }
+        [SugarColumn(ColumnName = "amount", ColumnDataType = "bigint")]
+        public long Amount { get; set; }
 
         /// <summary>
         /// 交易哈希。

--- a/TonPrediction.Application/Database/Repository/ITransactionRepository.cs
+++ b/TonPrediction.Application/Database/Repository/ITransactionRepository.cs
@@ -5,9 +5,9 @@ using QYQ.Base.SqlSugar;
 namespace TonPrediction.Application.Database.Repository
 {
     /// <summary>
-    /// 领奖记录仓库接口。
+    /// 领奖与退款交易记录仓库接口。
     /// </summary>
-    public interface IClaimRepository : IBaseRepository<ClaimEntity>, ITransientDependency
+    public interface ITransactionRepository : IBaseRepository<TransactionEntity>, ITransientDependency
     {
     }
 }

--- a/TonPrediction.Application/Services/ClaimService.cs
+++ b/TonPrediction.Application/Services/ClaimService.cs
@@ -14,12 +14,12 @@ namespace TonPrediction.Application.Services;
 /// </summary>
 public class ClaimService(
     IBetRepository betRepo,
-    IClaimRepository claimRepo,
+    ITransactionRepository txRepo,
     IWalletService walletService,
     IConfiguration configuration) : IClaimService
 {
     private readonly IBetRepository _betRepo = betRepo;
-    private readonly IClaimRepository _claimRepo = claimRepo;
+    private readonly ITransactionRepository _txRepo = txRepo;
     private readonly IWalletService _walletService = walletService;
     private readonly IConfiguration _configuration = configuration;
 
@@ -41,17 +41,17 @@ public class ClaimService(
 
         var result = await _walletService.TransferAsync(input.Address, amount);
 
-        var entity = new ClaimEntity
+        var entity = new TransactionEntity
         {
-            RoundId = input.RoundId,
+            BetId = bet.Id,
             UserAddress = rawAddress,
-            Reward = amount,
+            Amount = amount,
             TxHash = result.TxHash,
             Status = result.Status,
             Lt = result.Lt,
             Timestamp = result.Timestamp
         };
-        await _claimRepo.InsertAsync(entity);
+        await _txRepo.InsertAsync(entity);
 
         bet.Claimed = true;
         bet.TreasuryFee = fee;

--- a/TonPrediction.Application/Services/RoundService.cs
+++ b/TonPrediction.Application/Services/RoundService.cs
@@ -80,7 +80,7 @@ public class RoundService(IRoundRepository roundRepo, IBetRepository betRepo, IO
         }
 
         var latest = await _roundRepo.GetLatestAsync(symbol);
-        var intervalSec = predictionConfig.Value.RoundIntervalSeconds;
+        var intervalSec = predictionConfig.CurrentValue.RoundIntervalSeconds;
         var startTime = latest?.CloseTime ?? DateTime.UtcNow;
         var startEpoch = (latest?.Epoch ?? 0) + 1;
         var fallback = new UpcomingRoundOutput

--- a/TonPrediction.Infrastructure/Database/Migrations/InitMigration.cs
+++ b/TonPrediction.Infrastructure/Database/Migrations/InitMigration.cs
@@ -17,7 +17,7 @@ namespace TonPrediction.Infrastructure.Database.Migrations
             db.CodeFirst.InitTables<RoundEntity>();
             db.CodeFirst.InitTables<BetEntity>();
             db.CodeFirst.InitTables<PriceSnapshotEntity>();
-            db.CodeFirst.InitTables<ClaimEntity>();
+            db.CodeFirst.InitTables<TransactionEntity>();
             db.CodeFirst.InitTables<StateEntity>();
             db.CodeFirst.InitTables<PnlStatEntity>();
         }

--- a/TonPrediction.Infrastructure/Database/Repository/TransactionRepository.cs
+++ b/TonPrediction.Infrastructure/Database/Repository/TransactionRepository.cs
@@ -9,13 +9,13 @@ using TonPrediction.Application.Database.Repository;
 namespace TonPrediction.Infrastructure.Database.Repository
 {
     /// <summary>
-    /// 领奖记录仓库实现。
+    /// 交易记录仓库实现。
     /// </summary>
     /// <param name="logger">日志组件。</param>
     /// <param name="options">数据库配置。</param>
     /// <param name="dbType">数据库类型。</param>
-    public class ClaimRepository(ILogger<ClaimRepository> logger, IOptionsMonitor<DatabaseConfig> options, DbType dbType = DbType.MySql)
-        : BaseRepository<ClaimEntity>(logger, options.CurrentValue.Default, dbType), IClaimRepository
+    public class TransactionRepository(ILogger<TransactionRepository> logger, IOptionsMonitor<DatabaseConfig> options, DbType dbType = DbType.MySql)
+        : BaseRepository<TransactionEntity>(logger, options.CurrentValue.Default, dbType), ITransactionRepository
     {
     }
 }

--- a/TonPrediction.Test/RoundServiceTests.cs
+++ b/TonPrediction.Test/RoundServiceTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Moq;
 using TonPrediction.Application.Database.Entities;
 using TonPrediction.Application.Database.Repository;
 using TonPrediction.Application.Enums;
+using TonPrediction.Application.Config;
 using TonPrediction.Application.Services;
 using Xunit;
 
@@ -69,7 +71,8 @@ public class RoundServiceTests
         var betRepo = new Mock<IBetRepository>();
         betRepo.Setup(b => b.GetByAddressAndRoundsAsync("addr", It.IsAny<long[]>(), default))
             .ReturnsAsync(bets);
-        var service = new RoundService(roundRepo.Object, new ConfigurationBuilder().Build(), betRepo.Object);
+        var option = Mock.Of<IOptionsMonitor<PredictionConfig>>(o => o.CurrentValue == new PredictionConfig());
+        var service = new RoundService(roundRepo.Object, betRepo.Object, option);
 
         var result = await service.GetRecentAsync("addr", "ton", 2);
 
@@ -104,7 +107,8 @@ public class RoundServiceTests
         var roundRepo = new Mock<IRoundRepository>();
         roundRepo.Setup(r => r.GetRecentAsync("ton", 1)).ReturnsAsync(rounds);
         var betRepo = new Mock<IBetRepository>();
-        var service = new RoundService(roundRepo.Object, new ConfigurationBuilder().Build(), betRepo.Object);
+        var option = Mock.Of<IOptionsMonitor<PredictionConfig>>(o => o.CurrentValue == new PredictionConfig());
+        var service = new RoundService(roundRepo.Object, betRepo.Object, option);
 
         var result = await service.GetRecentAsync(null, "ton", 1);
 


### PR DESCRIPTION
## Summary
- rename `ClaimEntity` to `TransactionEntity`
- record refunds with bet ID and amount
- adjust claim service and scheduler for new repository

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release` *(failed: build canceled)*

------
https://chatgpt.com/codex/tasks/task_e_687722a16df4832392bf0e15e58bbe98