### PR TITLE
Update leaderboard output structure

### DIFF
--- a/TonPrediction.Application/Output/LeaderboardOutput.cs
+++ b/TonPrediction.Application/Output/LeaderboardOutput.cs
@@ -11,12 +11,7 @@ public class LeaderboardOutput
     public List<LeaderboardItemOutput> List { get; set; } = new();
 
     /// <summary>
-    /// 指定地址的排名，可为空。
+    /// 指定地址的排行信息，可为空。
     /// </summary>
-    public int? AddressRank { get; set; }
-
-    /// <summary>
-    /// 指定地址所在页码，可为空。
-    /// </summary>
-    public int? AddressPage { get; set; }
+    public LeaderboardItemOutput? Self { get; set; }
 }

--- a/TonPrediction.Application/Services/LeaderboardService.cs
+++ b/TonPrediction.Application/Services/LeaderboardService.cs
@@ -50,8 +50,22 @@ public class LeaderboardService(IPnlStatRepository repo) : ILeaderboardService
             var rank = await _repo.GetRankAsync(symbol, address.ToRawAddress(), rankBy);
             if (rank > 0)
             {
-                output.AddressRank = rank;
-                output.AddressPage = (rank - 1) / pageSize + 1;
+                var stat = await _repo.GetByAddressAsync(symbol, address.ToRawAddress());
+                if (stat != null)
+                {
+                    output.Self = new LeaderboardItemOutput
+                    {
+                        Rank = rank,
+                        Address = stat.UserAddress.ToFriendlyAddress(),
+                        Rounds = stat.Rounds,
+                        WinRounds = stat.WinRounds,
+                        LoseRounds = stat.Rounds - stat.WinRounds,
+                        WinRate = stat.Rounds > 0 ? ((decimal)stat.WinRounds / stat.Rounds).ToString("F2") : "0",
+                        TotalBet = stat.TotalBet.ToAmountString(),
+                        TotalReward = stat.TotalReward.ToAmountString(),
+                        NetProfit = (stat.TotalReward - stat.TotalBet).ToAmountString()
+                    };
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- adjust `LeaderboardOutput` to return personal rank info
- update `LeaderboardService` to populate `Self` item when address is specified

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release` *(fails: Unable to connect to any of the specified MySQL hosts)*

------
https://chatgpt.com/codex/tasks/task_e_6883214579a08323a0b87fa93b58413b