### PR TITLE
Fix leaderboard address API

### DIFF
--- a/TonPrediction.Api/Controllers/LeaderboardController.cs
+++ b/TonPrediction.Api/Controllers/LeaderboardController.cs
@@ -33,7 +33,7 @@ public class LeaderboardController(ILeaderboardService service) : ControllerBase
     /// 获取指定地址的排行榜信息。
     /// </summary>
     [HttpGet("address")]
-    public async Task<ApiResult<LeaderboardOutput>> GetByAddressAsync(
+    public async Task<ApiResult<LeaderboardItemOutput?>> GetByAddressAsync(
         [FromQuery] string address,
         [FromQuery] string symbol = "ton",
         [FromQuery] RankByType rankBy = RankByType.NetProfit)

--- a/TonPrediction.Application/Services/Interface/ILeaderboardService.cs
+++ b/TonPrediction.Application/Services/Interface/ILeaderboardService.cs
@@ -31,7 +31,7 @@ public interface ILeaderboardService : ITransientDependency
     /// <param name="address">用户地址。</param>
     /// <param name="symbol">币种符号。</param>
     /// <param name="rankBy">排序字段。</param>
-    Task<ApiResult<LeaderboardOutput>> GetByAddressAsync(
+    Task<ApiResult<LeaderboardItemOutput?>> GetByAddressAsync(
         string address,
         string symbol = "ton",
         RankByType rankBy = RankByType.NetProfit);


### PR DESCRIPTION
## Summary
- tweak API to return a single LeaderboardItemOutput when querying by address
- update service interface and implementation accordingly

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test --no-build -c Release` *(fails: Unable to connect to any of the specified MySQL hosts)*

------
https://chatgpt.com/codex/tasks/task_e_688328c58f448323b946ed19728b774a