### PR TITLE
Add address search endpoint

### DIFF
--- a/TON Prediction API.md
+++ b/TON Prediction API.md
@@ -373,6 +373,16 @@ GET /api/predictions/pnl
 | `rankBy`  | enum   | netProfit | rounds \| netProfit \| totalBet \| winRate |
 
 返回指定地址的排行信息以及前 10 名记录。
+
+### `GET /api/leaderboard/search`
+
+| 参数名   | 类型   | 默认值 | 说明                 |
+| -------- | ------ | ------ | -------------------- |
+| `keyword`| string |        | 地址关键字           |
+| `symbol` | string | TONUSD | 币种对               |
+| `limit`  | int    | 10     | 返回数量，<=100       |
+
+返回匹配的地址列表，地址为 user-friendly 格式。
 ## 1️⃣3️⃣ 领奖
 
 ### `POST /api/claim`

--- a/TonPrediction.Api/Controllers/LeaderboardController.cs
+++ b/TonPrediction.Api/Controllers/LeaderboardController.cs
@@ -40,4 +40,16 @@ public class LeaderboardController(ILeaderboardService service) : ControllerBase
     {
         return await _service.GetByAddressAsync(address, symbol, rankBy);
     }
+
+    /// <summary>
+    /// 模糊搜索地址。
+    /// </summary>
+    [HttpGet("search")]
+    public async Task<ApiResult<AddressListOutput>> SearchAddressAsync(
+        [FromQuery] string keyword,
+        [FromQuery] string symbol = "ton",
+        [FromQuery] int limit = 10)
+    {
+        return await _service.SearchAddressAsync(keyword, symbol, limit);
+    }
 }

--- a/TonPrediction.Application/Database/Repository/IPnlStatRepository.cs
+++ b/TonPrediction.Application/Database/Repository/IPnlStatRepository.cs
@@ -33,4 +33,12 @@ public interface IPnlStatRepository : IBaseRepository<PnlStatEntity>, ITransient
     /// <param name="address">用户地址。</param>
     /// <param name="rankBy">排序字段。</param>
     Task<int> GetRankAsync(string symbol, string address, RankByType rankBy);
+
+    /// <summary>
+    /// 模糊搜索地址。
+    /// </summary>
+    /// <param name="symbol">币种符号。</param>
+    /// <param name="keyword">地址关键字。</param>
+    /// <param name="limit">结果数量。</param>
+    Task<List<string>> SearchAddressAsync(string symbol, string keyword, int limit);
 }

--- a/TonPrediction.Application/Output/AddressListOutput.cs
+++ b/TonPrediction.Application/Output/AddressListOutput.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace TonPrediction.Application.Output;
+
+/// <summary>
+/// 地址列表结果。
+/// </summary>
+public class AddressListOutput
+{
+    /// <summary>
+    /// 匹配到的地址集合。
+    /// </summary>
+    public List<string> Addresses { get; set; } = new();
+}

--- a/TonPrediction.Application/Services/Interface/ILeaderboardService.cs
+++ b/TonPrediction.Application/Services/Interface/ILeaderboardService.cs
@@ -35,4 +35,15 @@ public interface ILeaderboardService : ITransientDependency
         string address,
         string symbol = "ton",
         RankByType rankBy = RankByType.NetProfit);
+
+    /// <summary>
+    /// 模糊搜索地址。
+    /// </summary>
+    /// <param name="keyword">地址关键字。</param>
+    /// <param name="symbol">币种符号。</param>
+    /// <param name="limit">返回数量限制。</param>
+    Task<ApiResult<AddressListOutput>> SearchAddressAsync(
+        string keyword,
+        string symbol = "ton",
+        int limit = 10);
 }

--- a/TonPrediction.Application/Services/LeaderboardService.cs
+++ b/TonPrediction.Application/Services/LeaderboardService.cs
@@ -4,6 +4,7 @@ using TonPrediction.Application.Enums;
 using TonPrediction.Application.Extensions;
 using TonPrediction.Application.Output;
 using TonPrediction.Application.Services.Interface;
+using System.Linq;
 
 namespace TonPrediction.Application.Services;
 
@@ -113,6 +114,26 @@ public class LeaderboardService(IPnlStatRepository repo) : ILeaderboardService
             NetProfit = (stat.TotalReward - stat.TotalBet).ToAmountString()
         };
 
+        api.SetRsult(ApiResultCode.Success, output);
+        return api;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<AddressListOutput>> SearchAddressAsync(
+        string keyword,
+        string symbol = "ton",
+        int limit = 10)
+    {
+        var api = new ApiResult<AddressListOutput>();
+        if (string.IsNullOrWhiteSpace(keyword))
+        {
+            api.SetRsult(ApiResultCode.ErrorParams, new AddressListOutput());
+            return api;
+        }
+
+        limit = limit is <= 0 or > 100 ? 10 : limit;
+        var list = await _repo.SearchAddressAsync(symbol, keyword.ToRawAddress(), limit);
+        var output = new AddressListOutput { Addresses = list.Select(a => a.ToFriendlyAddress()).ToList() };
         api.SetRsult(ApiResultCode.Success, output);
         return api;
     }


### PR DESCRIPTION
## Summary
- add `AddressListOutput` DTO
- support fuzzy address search in leaderboard repository and service
- expose `GET /api/leaderboard/search` endpoint
- document the new API in `TON Prediction API.md`
- ensure the returned addresses are user-friendly

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build` *(fails: Unable to connect to any of the specified MySQL hosts)*

------
https://chatgpt.com/codex/tasks/task_e_68832b483510832392e5ffc7995e6a0c